### PR TITLE
fixes #2885 - Add CLI option to set config file path

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -6,22 +6,25 @@ require 'clamp'
 # create fake command instance to use some global args before we start
 class PreParser < Clamp::Command
   option ["-v", "--verbose"], :flag, "be verbose"
+  option ["-c", "--config"], "CFG_FILE", "path to custom config file"
 end
 
 preparser = PreParser.new File.basename($0), {}
 begin
   preparser.parse ARGV
-rescue Clamp::UsageError => e
+rescue
 end
-
 
 # load user's settings
 require 'hammer_cli/settings'
 
 CFG_PATH = ['./config/cli_config.yml', '~/.foreman/cli_config.yml', '/etc/foreman/cli_config.yml']
 
-HammerCLI::Settings.load_from_file CFG_PATH
+if preparser.config
+  CFG_PATH.unshift preparser.config
+end
 
+HammerCLI::Settings.load_from_file CFG_PATH
 
 # setup logging
 require 'hammer_cli/logger'

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -4,6 +4,7 @@ module HammerCLI
   class MainCommand < AbstractCommand
 
     option ["-v", "--verbose"], :flag, "be verbose"
+    option ["-c", "--config"], "CFG_FILE", "path to custom config file"
 
     option ["-u", "--username"], "USERNAME", "username to access the remote system"
     option ["-p", "--password"], "PASSWORD", "password to access the remote system"


### PR DESCRIPTION
added support for custom config file on non-standart path. This file has highest priority and overrides values form configs in standard locations
