### PR TITLE
fixes #2884 - Configuration files in home dir are not found

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -35,6 +35,11 @@ if preparser.verbose?
   root_logger.appenders = root_logger.appenders << ::Logging.appenders.stdout(:layout => HammerCLI::Logger::COLOR_LAYOUT)
 end
 
+# log which config was loaded (now when we have logging)
+HammerCLI::Settings.path_history.each do |path|
+  logger.info "Configuration from the file #{path} has been loaded"
+end
+
 # load hammer core
 require 'hammer_cli'
 
@@ -42,7 +47,7 @@ require 'hammer_cli'
 modules = HammerCLI::Settings[:modules] || []
 modules.each do |m| 
   require m 
-  logger.info "Module #{m} loaded"
+  logger.info "Extension module #{m} loaded"
 end
 
 exit HammerCLI::MainCommand.run || 0

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'logging'
 
 module HammerCLI
 
@@ -13,7 +14,10 @@ module HammerCLI
         full_path = File.expand_path path
         if File.exists? full_path
           config = YAML::load(File.open(full_path))
-          load(config) if config
+          if config
+            load(config)
+            path_history << full_path
+          end
         end
       end
     end
@@ -24,6 +28,12 @@ module HammerCLI
 
     def self.clear
       settings.clear
+      path_history.clear
+    end
+
+    def self.path_history
+      @path_history ||= []
+      @path_history 
     end
 
     private

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -2,7 +2,7 @@ require_relative 'test_helper'
 
 describe HammerCLI::Settings do
 
-  after :each do
+  before :each do
     # clean up global settings
     HammerCLI::Settings.clear
   end
@@ -50,19 +50,40 @@ describe HammerCLI::Settings do
     settings[:b].must_be_nil
   end
 
+  context "load from file" do 
 
-  it "loads settings from file" do
-    settings1 = Tempfile.new 'settings'
-    settings1 << ":host: 'https://localhost/'\n"
-    settings1 << ":username: 'admin'\n"
-    settings1.close
-    settings2 = Tempfile.new 'settings2'
-    settings2 << ":host: 'https://localhost.localdomain/'\n"
-    settings2.close
-    settings.load_from_file [settings2.to_path, settings1.to_path]
-    settings[:host].must_equal 'https://localhost.localdomain/'
-    settings[:username].must_equal 'admin'
+    let(:config1) do
+      config1 = Tempfile.new 'config'
+      config1 << ":host: 'https://localhost/'\n"
+      config1 << ":username: 'admin'\n"
+      config1.close
+      config1
+    end 
+
+    let(:config2) do
+      config2 = Tempfile.new 'config2'
+      config2 << ":host: 'https://localhost.localdomain/'\n"
+      config2.close
+      config2
+    end
+
+    it "loads settings from file" do
+      settings.load_from_file [config2.to_path, config1.to_path]
+      settings[:host].must_equal 'https://localhost.localdomain/'
+      settings[:username].must_equal 'admin'
+    end
+
+    it "clears path history on clear invokation" do
+      settings.load_from_file [config2.to_path]
+      settings.clear
+      settings.path_history.must_equal []
+    end
+
+    it "store config path history" do
+      settings.load_from_file [config2.to_path, config1.to_path]
+      settings.path_history.must_equal [config1.to_path, config2.to_path]
+    end
+
   end
-
 end
 


### PR DESCRIPTION
Works for me. Relative path resolving depends on properly set $HOME env variable.

Added logging of where settings found config files
