### PR TITLE
fixes #2887 - global options --username nad --password 

### DIFF
--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -23,19 +23,11 @@ module HammerCLI
     end
 
     def password=(password)
-      @@password = password
-    end
-
-    def self.password
-      @@password
+      context[:password] = password
     end
 
     def username=(username)
-      @@username = username
-    end
-
-    def self.username
-      @@username
+      context[:username] = username
     end
 
   end


### PR DESCRIPTION
is better to store in context, that is shared among all subcommands
