### PR TITLE
fixes #2907 - Add log dir default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,13 @@ clone plugin with foreman commands
     $ rake install
     $ cd ..
     
-configure
+and configure. Configuration is by default looked for in ~/.foreman/ or in /etc/foreman/. 
+Optionally you can put your configuration in ./config/ or point hammer 
+to some other location using -c CONF_FILE option
 
-    $ cat <<EOF > ~/.foreman/cli_config.yml
-    :modules:
-        - hammer_cli_foreman
-    :host: 'https://localhost/'
-    :username: 'admin'
-    :password: 'changeme'
-    EOF
+You can start with config file template we created for you and update it to suit your needs. E.g.:
+
+    $ cp hammer-cli/config/cli_config.template.yaml ~/.foreman/cli_config.yml
 
 and run 
 

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -6,5 +6,6 @@
 :username: 'admin'
 :password: 'changeme'
 
-:log_dir: '/var/log/foreman'
+#:log_dir: '/var/log/foreman'
+:log_dir: '~/.foreman/log'
 :log_level: 'error'

--- a/lib/hammer_cli/logger.rb
+++ b/lib/hammer_cli/logger.rb
@@ -16,18 +16,20 @@ module HammerCLI
                          :file   => :yellow,
                          :method => :yellow)
 
-    pattern        = "[%5l %d %c] %m\n"
-    COLOR_LAYOUT   = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => 'bright')
-    NOCOLOR_LAYOUT = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => nil)
+    pattern         = "[%5l %d %c] %m\n"
+    COLOR_LAYOUT    = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => 'bright')
+    NOCOLOR_LAYOUT  = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => nil)
+    DEFAULT_LOG_DIR = '/var/log/foreman'
 
+    log_dir = File.expand_path(HammerCLI::Settings[:log_dir] || DEFAULT_LOG_DIR)
     begin
-      FileUtils.mkdir_p(HammerCLI::Settings[:log_dir], :mode => 0750)
+      FileUtils.mkdir_p(log_dir, :mode => 0750)
     rescue Errno::EACCES => e
-      puts "No permissions to create log dir #{HammerCLI::Settings[:log_dir]}"
+      puts "No permissions to create log dir #{log_dir}"
     end
 
     logger   = Logging.logger.root
-    filename = "#{HammerCLI::Settings[:log_dir]}/hammer.log"
+    filename = "#{log_dir}/hammer.log"
     begin
       logger.appenders = ::Logging.appenders.rolling_file('configure',
                                                           :filename => filename,


### PR DESCRIPTION
added
- default log_dir (/var/log/foreamn)
- support for ~ in :log_dir
- suggested to use config template in install instructions
