### PR TITLE
fixes #2906 - test are broken on 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 #gem 'hammer_cli_signo', :path => '../hammer-cli-signo'
 
 gem 'pry'
-gem 'pry-debugger'
+gem 'pry-debugger', :platforms => [:ruby_19]
 
 group :test do
   gem 'thor'
@@ -16,6 +16,6 @@ group :test do
   gem 'simplecov'
   gem 'mocha'
   gem 'rake'
-  gem 'psych'
+  gem 'psych', :platforms => [:ruby_19]
   gem 'netrc'
 end

--- a/lib/hammer_cli/apipie/options.rb
+++ b/lib/hammer_cli/apipie/options.rb
@@ -84,9 +84,8 @@ module HammerCLI::Apipie
         # FIXME: There is a bug in apipie, it does not produce correct expected type for Arrays
         # When it's fixed, we should test param["expected_type"] == "array"
         if param["validator"].include? "Array"
-          return lambda do |val|
-            return val.split "," if val.is_a? String
-            return []
+          lambda do |val|
+            val.is_a?(String) ? val.split(",") : []
           end
         end
       end

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -68,20 +68,20 @@ describe HammerCLI::Settings do
     end
 
     it "loads settings from file" do
-      settings.load_from_file [config2.to_path, config1.to_path]
+      settings.load_from_file [config2.path, config1.path]
       settings[:host].must_equal 'https://localhost.localdomain/'
       settings[:username].must_equal 'admin'
     end
 
     it "clears path history on clear invokation" do
-      settings.load_from_file [config2.to_path]
+      settings.load_from_file [config2.path]
       settings.clear
       settings.path_history.must_equal []
     end
 
     it "store config path history" do
-      settings.load_from_file [config2.to_path, config1.to_path]
-      settings.path_history.must_equal [config1.to_path, config2.to_path]
+      settings.load_from_file [config2.path, config1.path]
+      settings.path_history.must_equal [config1.path, config2.path]
     end
 
   end


### PR DESCRIPTION
This PR fixes the tests on Ruby 1.8. 
- SimpleCov coverage reports do not work with a warning, not an issue IMO
- the lambda in apipie options needs check. It was failing (in Ruby 1.8) with  "LocalJumpError: unexpected return" on line 88 an it is not clear to me why.
