### PR TITLE
Added watch method to logger for easier debugging

### DIFF
--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -6,6 +6,9 @@
 :username: 'admin'
 :password: 'changeme'
 
+# :watch_plain: true disables color output of logger.watch in Clamp commands
+:watch_plain: false
+
 #:log_dir: '/var/log/foreman'
 :log_dir: '~/.foreman/log'
 :log_level: 'error'

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -27,5 +27,6 @@ EOF
   s.add_dependency 'terminal-table'
   s.add_dependency 'rest-client'
   s.add_dependency 'logging'
+  s.add_dependency 'awesome_print'
 
 end

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -1,5 +1,6 @@
 require 'hammer_cli/autocompletion'
 require 'hammer_cli/exception_handler'
+require 'hammer_cli/logger_watch'
 require 'clamp'
 require 'logging'
 
@@ -53,6 +54,8 @@ module HammerCLI
 
     def logger name=self.class
       logger = Logging.logger[name]
+      logger.extend(HammerCLI::Logger::Watch) if not logger.respond_to? :watch
+      logger
     end
 
     def validator

--- a/lib/hammer_cli/apipie/read_command.rb
+++ b/lib/hammer_cli/apipie/read_command.rb
@@ -16,6 +16,7 @@ module HammerCLI::Apipie
 
       def execute
         d = retrieve_data
+        logger.watch "Retrieved data: ", d
         print_records d
         return 0
       end

--- a/lib/hammer_cli/logger_watch.rb
+++ b/lib/hammer_cli/logger_watch.rb
@@ -1,0 +1,14 @@
+require 'awesome_print'
+
+module HammerCLI
+  module Logger
+    module Watch
+      def watch(label, obj, options={})
+        if debug?
+          options = { :plain => HammerCLI::Settings[:watch_plain], :indent => -2 }.merge(options)
+          debug label + "\n" + obj.ai(options)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -78,6 +78,46 @@ describe HammerCLI::AbstractCommand do
       @log_output.read.must_include "ERROR  My logger : Test"
     end
 
+    class TestLogCmd3 < HammerCLI::AbstractCommand
+      def execute
+        logger.watch "Test", {}
+        0
+      end
+    end
+
+    it "should have logger that can inspect object" do
+      test_command = Class.new(TestLogCmd3).new("")
+      test_command.run []
+      @log_output.read.must_include "DEBUG  TestLogCmd3 : Test\n{}"
+    end
+
+    class TestLogCmd4 < HammerCLI::AbstractCommand
+      def execute
+        logger.watch "Test", { :a => 'a' }, { :plain => true }
+        0
+      end
+    end
+
+    it "should have logger.watch output without colors" do
+      test_command = Class.new(TestLogCmd4).new("")
+      test_command.run []
+      @log_output.read.must_include "DEBUG  TestLogCmd4 : Test\n{\n  :a => \"a\"\n}"
+    end
+
+    class TestLogCmd5 < HammerCLI::AbstractCommand
+      def execute
+        logger.watch "Test", { :a => 'a' }
+        0
+      end
+    end
+
+    it "should have logger.watch colorized output switch in settings" do
+      test_command = Class.new(TestLogCmd5).new("")
+      HammerCLI::Settings.clear
+      HammerCLI::Settings.load(:watch_plain => true)
+      test_command.run []
+      @log_output.read.must_include "DEBUG  TestLogCmd5 : Test\n{\n  :a => \"a\"\n}"
+    end
   end
 
 end


### PR DESCRIPTION
- in commands there is logger.watch label, object, options that logs in debug level
- in config :watch_plain = true can disable colorized output
- apipie read_command automatically log retrieved data when in debug level
