### PR TITLE
fixes #2939 - autocompletion doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ and run
         -h, --help                    print help
 
 
+Autocompletion
+--------------
+
+It is necessary to copy script hammer_cli_complete to the bash_completion.d directory. 
+
+    $ sudo cp hammer-cli/hammer_cli_complete /etc/bash_completion.d/
+
+Then in new shell the completion should work.
+
+
 How to test
 ------------
 

--- a/hammer_cli_complete
+++ b/hammer_cli_complete
@@ -4,10 +4,8 @@
 # vim:ts=2:sw=2:et:
 #
 
-_HAMMER_BUNDLER_CMD="bundle exec"
-
 _hammer() {
-  COMPREPLY=($($_HAMMER_BUNDLER_CMD hammer --autocomplete '${COMP_WORDS[*]}'))
+  COMPREPLY=($(hammer --autocomplete "${COMP_WORDS[*]}"))
   return 0
 }
 

--- a/lib/hammer_cli/autocompletion.rb
+++ b/lib/hammer_cli/autocompletion.rb
@@ -4,17 +4,19 @@ module HammerCLI
     def autocomplete(line, prefix=[])
       endings = []
       formated_prefix = prefix.join(' ')
-      all_options = collect_all_options
 
       if line.length == 0 # look for possible next words
-        endings = all_options.keys.map { |e| [e, formated_prefix]}
-      elsif line.length == 1 && !all_options.key?(line[0]) # look for endings
-        endings = all_options.select { |k,v| k if k.start_with? line[0] }.keys.map { |e| [e, formated_prefix]}
+        all_options = collect_all_options
+        endings = all_options.keys.map { |e| [e, formated_prefix] }
+      elsif line.length == 1 && !(find_subcommand(line[0]) || find_option(line[0])) # look for endings
+        all_options = collect_all_options
+        endings = all_options.select { |k,v| k if k.start_with? line[0] }.keys.map { |e| [e, formated_prefix] }
       else # dive into subcommands
-        if all_options.key?(line[0]) && all_options[line[0]].class <= Clamp::Subcommand
+        subcommand = find_subcommand line[0]
+        if subcommand
           command = line.shift
           prefix << command
-          endings = all_options[command].subcommand_class.autocomplete(line, prefix)
+          endings = subcommand.subcommand_class.autocomplete(line, prefix)
         end
       end
       endings
@@ -25,6 +27,7 @@ module HammerCLI
 
       if has_subcommands?
         recognised_subcommands.each do |item|
+          
           label, _ = item.help
           all_options[label] = item
         end


### PR DESCRIPTION
This patch makes it work somehow, but there is a lot to improve
- performance - with every <tab> hammer is triggered with all the config loading, log setup, command generation. We may need different approach and preprocess the data 
- options completion - with current algorithm options completion does work only for one option
