### PR TITLE
fixes #3534 - mime-types require ruby >= 1.9.2 since 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
+gem 'mime-types', '< 2.0.0', :platforms => [:ruby_18]
+
 #gem 'hammer_cli_foreman', :path => '../hammer-cli-foreman'
 #gem 'hammer_cli_katello', :path => '../hammer-cli-katello'
 #gem 'hammer_cli_signo', :path => '../hammer-cli-signo'

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -32,5 +32,6 @@ EOF
   s.add_dependency 'table_print'
   s.add_dependency 'highline'
   s.add_dependency 'fastercsv' if RUBY_VERSION < "1.9.0"
+  s.add_dependency 'mime-types', '< 2.0.0' if RUBY_VERSION < "1.9.0"
 
 end


### PR DESCRIPTION
mime-types version pinned < 2.0 for ruby 1.8.7
