### PR TITLE
fixes #3246 - printing id and names of created resources

### DIFF
--- a/lib/hammer_cli.rb
+++ b/lib/hammer_cli.rb
@@ -1,3 +1,4 @@
+require 'hammer_cli/utils'
 require 'hammer_cli/version'
 require 'hammer_cli/exit_codes'
 require 'hammer_cli/settings'

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -53,7 +53,7 @@ module HammerCLI
     end
 
     def exception_handler
-      @exception_handler ||= exception_handler_class.new(:context=>context, :adapter=>adapter)
+      @exception_handler ||= exception_handler_class.new(:output => output)
     end
 
     def initialize(*args)
@@ -94,6 +94,10 @@ module HammerCLI
       output_definition.append dsl.fields
     end
 
+    def output
+      @output ||= HammerCLI::Output::Output.new(context, :default_adapter => adapter)
+    end
+
     def output_definition
       self.class.output_definition
     end
@@ -106,12 +110,11 @@ module HammerCLI
     protected
 
     def print_records(definition, records)
-      HammerCLI::Output::Output.print_records(definition, records, context,
-        :adapter => adapter)
+      output.print_records(definition, records)
     end
 
-    def print_message(msg)
-      HammerCLI::Output::Output.print_message(msg, context, :adapter=>adapter)
+    def print_message(msg, msg_params={})
+      output.print_message(msg, msg_params)
     end
 
     def logger(name=self.class)

--- a/lib/hammer_cli/apipie/write_command.rb
+++ b/lib/hammer_cli/apipie/write_command.rb
@@ -7,16 +7,24 @@ module HammerCLI::Apipie
     include HammerCLI::Messages
 
     def execute
-      send_request
-      print_success_message 
+      response = send_request
+      print_success_message(response)
       return HammerCLI::EX_OK
     end
 
     protected
 
-    def print_success_message
-      msg = success_message
-      print_message(msg) unless msg.nil?
+    def success_message_params(response)
+      response
+    end
+
+    def print_success_message(response)
+      if success_message
+        print_message(
+          success_message,
+          success_message_params(response)
+        )
+      end
     end
 
     def send_request

--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -6,8 +6,7 @@ module HammerCLI
 
     def initialize(options={})
       @logger = Logging.logger['Exception']
-      @context = options[:context] || {}
-      @adapter = options[:adapter] || :base
+      @output = options[:output]
     end
 
     def mappings
@@ -25,6 +24,10 @@ module HammerCLI
       raise e
     end
 
+    def output
+      @output || HammerCLI::Output::Output.new
+    end
+
     protected
 
     def print_error(error)
@@ -32,9 +35,9 @@ module HammerCLI
       @logger.error error
 
       if @options[:heading]
-        HammerCLI::Output::Output.print_error @options[:heading], error, @context, :adapter => @adapter
+        output.print_error(@options[:heading], error)
       else
-        HammerCLI::Output::Output.print_error error, nil, @context, :adapter => @adapter
+        output.print_error(error)
       end
     end
 

--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -11,27 +11,27 @@ module HammerCLI::Output::Adapter
       @formatters = HammerCLI::Output::Formatters::FormatterLibrary.new(filter_formatters(formatters))
     end
 
-    def print_message(msg)
-      puts msg
+    def print_message(msg, msg_params={})
+      puts msg.format(msg_params)
     end
 
-    def print_error(msg, details=nil)
+    def print_error(msg, details=nil, msg_params={})
       details = details.split("\n") if details.kind_of? String
 
       if details
         indent = "  "
-        $stderr.puts msg+":"
-        $stderr.puts indent + details.join("\n"+indent)
-      else
-        $stderr.puts msg
+        msg += ":\n"
+        msg += indent + details.join("\n"+indent)
       end
+
+      $stderr.puts msg.format(msg_params)
     end
 
     def print_records(fields, data)
       raise NotImplementedError
     end
 
-    private 
+    private
 
     def filter_formatters(formatters_map)
       formatters_map ||= {}

--- a/lib/hammer_cli/output/adapter/silent.rb
+++ b/lib/hammer_cli/output/adapter/silent.rb
@@ -3,10 +3,10 @@ module HammerCLI::Output::Adapter
 
   class Silent < Abstract
 
-    def print_message(msg)
+    def print_message(msg, msg_params={})
     end
 
-    def print_error(msg, details=[])
+    def print_error(msg, details=[], msg_params={})
     end
 
     def print_records(fields, data)

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -1,0 +1,18 @@
+
+class String
+
+  # string formatting for ruby 1.8
+  def format(params)
+    if params.is_a? Hash
+      array_params = self.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
+        name = name[0]
+        params[name.to_s] || params[name.to_sym]
+      end
+
+      self.gsub(/%[<{]([^>}]*)[>}]/, '%') % array_params
+    else
+      self % params
+    end
+  end
+
+end

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -12,6 +12,10 @@ describe HammerCLI::AbstractCommand do
       cmd.adapter.must_equal :base
     end
 
+    it "should provide instance of output with default adapter set" do
+      cmd.output.default_adapter.must_equal cmd.adapter
+    end
+
     it "should hold instance of output definition" do
       cmd.output_definition.must_be_instance_of HammerCLI::Output::Definition
     end

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -8,42 +8,35 @@ describe HammerCLI::ExceptionHandler do
     @log_output.reset
   end
 
-  let(:output) { HammerCLI::Output::Output }
-  let(:handler) { HammerCLI::ExceptionHandler.new(:adapter => :silent)}
+  let(:output) { HammerCLI::Output::Output.new }
+  let(:handler) { HammerCLI::ExceptionHandler.new(:output => output)}
   let(:heading) { "Something went wrong" }
 
-  it "should pass context" do
-    context = { :test => :value }
-    eh = HammerCLI::ExceptionHandler.new(:adapter => :silent, :context => context)
-    output.expects(:print_error).with(heading, "Invalid username or password", context, { :adapter => :silent })
-    eh.handle_exception(RestClient::Unauthorized.new, :heading => heading)
-  end
-
   it "should handle unauthorized" do
-    output.expects(:print_error).with(heading, "Invalid username or password", {}, { :adapter => :silent })
+    output.expects(:print_error).with(heading, "Invalid username or password")
     handler.handle_exception(RestClient::Unauthorized.new, :heading => heading)
   end
 
   it "should handle general exception" do
-    output.expects(:print_error).with(heading, "Error: message", {}, { :adapter => :silent })
+    output.expects(:print_error).with(heading, "Error: message")
     handler.handle_exception(Exception.new('message'), :heading => heading)
   end
 
   it "should handle unknown exception" do
-    output.expects(:print_error).with(heading, "Error: message", {}, { :adapter => :silent })
+    output.expects(:print_error).with(heading, "Error: message")
     MyException = Class.new(Exception)
     handler.handle_exception(MyException.new('message'), :heading => heading)
   end
 
   it "should handle resource not found" do
     ex = RestClient::ResourceNotFound.new
-    output.expects(:print_error).with(heading, ex.message, {}, { :adapter => :silent })
+    output.expects(:print_error).with(heading, ex.message)
     handler.handle_exception(ex, :heading => heading)
   end
 
   it "should log the error" do
     ex = RestClient::ResourceNotFound.new
-    output.stubs(:print_error).returns('')
+    output.default_adapter = :silent
     handler.handle_exception(ex)
     @log_output.readline.strip.must_equal 'ERROR  Exception : Resource Not Found'
   end

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -45,8 +45,16 @@ describe HammerCLI::Output::Adapter::Abstract do
     adapter = adapter_class.new({}, {:type => [formatter1, formatter2]})
   end
 
-  it "should print message to stdout" do
-    proc { adapter.print_message("MESSAGE") }.must_output(/.*MESSAGE.*/, "")
+
+  context "messages" do
+    it "should print message to stdout" do
+      proc { adapter.print_message("MESSAGE") }.must_output(/.*MESSAGE.*/, "")
+    end
+
+    it "should print formatted message with parameters" do
+      proc { adapter.print_message("MESSAGE %{a}s, %{b}s", :a => 'A', :b => 'B') }.must_output(/.*MESSAGE A, B.*/, "")
+    end
+
   end
 
   it "should raise not implemented on print_records" do
@@ -64,12 +72,23 @@ describe HammerCLI::Output::Adapter::Abstract do
                             "  details\n"
     }
 
+    let(:expected_formatted_output) { "MESSAGE A, B:\n"+
+                                      "  error A\n"+
+                                      "  error B\n"
+    }
+
     it "should print list details of error to stderr" do
       proc { adapter.print_error("MESSAGE", ["error", "message", "details"]) }.must_output("", expected_output)
     end
 
     it "should print string details of error to stderr" do
       proc { adapter.print_error("MESSAGE", "error\nmessage\ndetails") }.must_output("", expected_output)
+    end
+
+    it "should print formatted message with parameters" do
+      proc {
+        adapter.print_error("MESSAGE %{a}s, %{b}s", ["error %{a}s", "error %{b}s"], :a => 'A', :b => 'B')
+      }.must_output("", expected_formatted_output)
     end
 
   end

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -44,7 +44,7 @@ describe HammerCLI::Output::Adapter::CSValues do
     end
 
     context "formatters" do
-      it "should apply formatters" do 
+      it "should apply formatters" do
         class DotFormatter < HammerCLI::Output::Formatters::FieldFormatter
           def format(data)
             '-DOT-'
@@ -56,6 +56,20 @@ describe HammerCLI::Output::Adapter::CSValues do
         out.must_match(/.*-DOT-.*/)
       end
     end
+  end
+
+  context "print message" do
+
+    it "shoud print a message" do
+      proc { adapter.print_message("SOME MESSAGE") }.must_output("Message\nSOME MESSAGE\n", "")
+    end
+
+    it "should print message, id and name of created/updated record" do
+      proc {
+        adapter.print_message("SOME MESSAGE", "id" => 83, "name" => "new_record")
+      }.must_output("Message,Id,Name\nSOME MESSAGE,83,new_record\n", "")
+    end
+
   end
 
 end

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -1,0 +1,35 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+
+
+describe String do
+
+  context "formatting" do
+
+    let(:str) { "AA%<a>s BB%<b>s" }
+    let(:curly_str) { "AA%{a}s BB%{b}s" }
+    let(:pos_str) { "AA%s BB%s" }
+
+    it "should not fail without expected parameters" do
+      str.format({}).must_equal 'AA BB'
+    end
+
+    it "should replace positional parameters" do
+      pos_str.format(['A', 'B']).must_equal 'AAA BBB'
+    end
+
+    it "should replace named parameters" do
+      str.format(:a => 'A', :b => 'B').must_equal 'AAA BBB'
+    end
+
+    it "should replace named parameters with string keys" do
+      str.format('a' => 'A', 'b' => 'B').must_equal 'AAA BBB'
+    end
+
+    it "should replace named parameters marked with curly brackets" do
+      curly_str.format(:a => 'A', :b => 'B').must_equal 'AAA BBB'
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
- output turned back to an object
- print_message now takes the message and arguments, which is the created/updated
  resource in case of write commands
- csv output adapter check if there is name or id available and prints it
