### PR TITLE
Ref #3766 - V2 format changed

### DIFF
--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -10,6 +10,8 @@
 # :watch_plain: true disables color output of logger.watch in Clamp commands
 :watch_plain: false
 
+
 #:log_dir: '/var/log/foreman'
 :log_dir: '~/.foreman/log'
 :log_level: 'error'
+:log_api_calls: false

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -122,8 +122,12 @@ module HammerCLI
 
     protected
 
-    def print_records(definition, records)
-      output.print_records(definition, records)
+    def print_record(definition, record)
+      output.print_record(definition, record)
+    end
+
+    def print_collection(definition, collection)
+      output.print_collection(definition, collection)
     end
 
     def print_message(msg, msg_params={})

--- a/lib/hammer_cli/apipie/read_command.rb
+++ b/lib/hammer_cli/apipie/read_command.rb
@@ -6,7 +6,7 @@ module HammerCLI::Apipie
 
       def execute
         d = retrieve_data
-        logger.watch "Retrieved data: ", d
+        logger.debug "Retrieved data: " + d.ai(:raw => true) if HammerCLI::Settings.get(:log_api_calls)
         print_data d
         return HammerCLI::EX_OK
       end
@@ -18,7 +18,7 @@ module HammerCLI::Apipie
       end
 
       def print_data(records)
-        print_records(output_definition, records)
+        print_collection(output_definition, records)
       end
 
       def request_params

--- a/lib/hammer_cli/apipie/resource.rb
+++ b/lib/hammer_cli/apipie/resource.rb
@@ -34,7 +34,10 @@ module HammerCLI::Apipie
     end
 
     def call(method_name, params=nil)
-      instance.send(method_name, params)
+      Logging.logger[resource_class.name].debug "Calling '#{method_name}' with params #{params.ai}" if HammerCLI::Settings.get(:log_api_calls)
+      result = instance.send(method_name, params)
+      Logging.logger[resource_class.name].debug "Method '#{method_name}' responded with #{result[0].ai}" if HammerCLI::Settings.get(:log_api_calls)
+      result
     end
 
     private

--- a/lib/hammer_cli/apipie/write_command.rb
+++ b/lib/hammer_cli/apipie/write_command.rb
@@ -7,9 +7,7 @@ module HammerCLI::Apipie
     include HammerCLI::Messages
 
     def execute
-      response = send_request
-      logger.watch "Retrieved data: ", response
-      print_success_message(response)
+      print_success_message(send_request)
       return HammerCLI::EX_OK
     end
 

--- a/lib/hammer_cli/output.rb
+++ b/lib/hammer_cli/output.rb
@@ -4,4 +4,5 @@ require File.join(File.dirname(__FILE__), 'output/formatters')
 require File.join(File.dirname(__FILE__), 'output/adapter')
 require File.join(File.dirname(__FILE__), 'output/definition')
 require File.join(File.dirname(__FILE__), 'output/dsl')
+require File.join(File.dirname(__FILE__), 'output/record_collection')
 

--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -27,7 +27,11 @@ module HammerCLI::Output::Adapter
       $stderr.puts msg.format(msg_params)
     end
 
-    def print_records(fields, data)
+    def print_record(fields, record)
+      raise NotImplementedError
+    end
+
+    def print_collection(fields, collection)
       raise NotImplementedError
     end
 

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -8,10 +8,14 @@ module HammerCLI::Output::Adapter
       [:flat, :screen]
     end
 
-    def print_records(fields, data)
+    def print_record(fields, record)
+      print_collection(fields, [record].flatten(1))
+    end
+
+    def print_collection(fields, collection)
       self.fields = fields
 
-      data.each do |d|
+      collection.each do |d|
         fields.collect do |f|
           render_field(f, d)
         end

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -16,12 +16,16 @@ module HammerCLI::Output::Adapter
       [:flat]
     end
 
-    def print_records(fields, data)
+    def print_record(fields, record)
+      print_collection(fields, [record].flatten(1))
+    end
+
+    def print_collection(fields, collection)
       csv_string = generate do |csv|
         # labels
         csv << fields.select{ |f| !(f.class <= Fields::Id) || @context[:show_ids] }.map { |f| f.label }
         # data
-        data.each do |d|
+        collection.each do |d|
           csv << fields.inject([]) do |row, f|
             unless f.class <= Fields::Id && !@context[:show_ids]
               value = (f.get_value(d) || '')

--- a/lib/hammer_cli/output/adapter/silent.rb
+++ b/lib/hammer_cli/output/adapter/silent.rb
@@ -9,7 +9,10 @@ module HammerCLI::Output::Adapter
     def print_error(msg, details=[], msg_params={})
     end
 
-    def print_records(fields, data)
+    def print_record(fields, record)
+    end
+
+    def print_collection(fields, collection)
     end
 
   end

--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -8,11 +8,16 @@ module HammerCLI::Output::Adapter
       [:screen, :flat]
     end
 
-    def print_records(fields, data)
+    def print_record(fields, record)
+      print_collection(fields, [record].flatten(1))
+    end
 
-      rows = data.collect do |d|
+    def print_collection(fields, collection)
+
+      rows = collection.collect do |d|
         row = {}
         fields.each do |f|
+
           row[f.label.to_sym] = f.get_value(d) || ""
         end
         row

--- a/lib/hammer_cli/output/output.rb
+++ b/lib/hammer_cli/output/output.rb
@@ -16,8 +16,15 @@ module HammerCLI::Output
       adapter.print_error(msg.to_s, details, msg_params)
     end
 
-    def print_records(definition, records)
-      adapter.print_records(definition.fields, [records].flatten(1))
+    def print_record(definition, record)
+      adapter.print_record(definition.fields, record)
+    end
+
+    def print_collection(definition, collection)
+      unless collection.class <= HammerCLI::Output::RecordCollection
+        collection = HammerCLI::Output::RecordCollection.new([collection].flatten(1))
+      end
+      adapter.print_collection(definition.fields, collection)
     end
 
     def adapter

--- a/lib/hammer_cli/output/record_collection.rb
+++ b/lib/hammer_cli/output/record_collection.rb
@@ -1,0 +1,35 @@
+module HammerCLI::Output
+
+
+  class MetaData
+
+    attr_accessor :total, :subtotal, :page, :per_page, :search, :sort_by, :sort_order
+
+    def initialize(options={})
+      @total = options[:total]
+      @subtotal = options[:subtotal]
+      @page = options[:page]
+      @per_page = options[:per_page]
+      @search = options[:search]
+      @sort_by = options[:sort_by]
+      @sort_order = options[:sort_order]
+    end
+
+  end
+
+
+  class RecordCollection < Array
+
+    attr_accessor :meta
+
+    def initialize(data, options={})
+      super [data].flatten(1)
+      if options.has_key?(:meta) && options[:meta].class <= MetaData
+        @meta = options[:meta]
+      else
+        @meta = MetaData.new(options)
+      end
+    end
+
+  end
+end

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -57,8 +57,8 @@ describe HammerCLI::Output::Adapter::Abstract do
 
   end
 
-  it "should raise not implemented on print_records" do
-    proc { adapter.print_records([], []) }.must_raise NotImplementedError
+  it "should raise not implemented on print_collection" do
+    proc { adapter.print_collection([], HammerCLI::Output::RecordCollection.new([])) }.must_raise NotImplementedError
   end
 
   context "error messages" do

--- a/test/unit/output/adapter/base_test.rb
+++ b/test/unit/output/adapter/base_test.rb
@@ -4,22 +4,22 @@ describe HammerCLI::Output::Adapter::Base do
 
   let(:adapter) { HammerCLI::Output::Adapter::Base.new }
 
-  context "print_records" do
+  context "print_collection" do
 
     let(:field_name) { Fields::DataField.new(:path => [:name], :label => "Name") }
     let(:fields) {
       [field_name]
     }
-    let(:data) {[{
+    let(:data) { HammerCLI::Output::RecordCollection.new [{
       :name => "John Doe"
     }]}
 
     it "should print field name" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*Name[ ]*:.*/, "")
+      proc { adapter.print_collection(fields, data) }.must_output(/.*Name[ ]*:.*/, "")
     end
 
     it "should print field value" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*John Doe.*/, "")
+      proc { adapter.print_collection(fields, data) }.must_output(/.*John Doe.*/, "")
     end
 
   end

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -4,24 +4,25 @@ describe HammerCLI::Output::Adapter::CSValues do
 
   let(:adapter) { HammerCLI::Output::Adapter::CSValues.new }
 
-  context "print_records" do
+  context "print_collection" do
 
     let(:field_name) { Fields::DataField.new(:path => [:name], :label => "Name") }
     let(:field_started_at) { Fields::DataField.new(:path => [:started_at], :label => "Started At") }
     let(:fields) {
       [field_name, field_started_at]
     }
-    let(:data) {[{
+    let(:data) { HammerCLI::Output::RecordCollection.new [{
       :name => "John Doe",
       :started_at => "2000"
     }]}
 
+
     it "should print column name" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*Name,Started At.*/, "")
+      proc { adapter.print_collection(fields, data) }.must_output(/.*Name,Started At.*/, "")
     end
 
     it "should print field value" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*John Doe.*/, "")
+      proc { adapter.print_collection(fields, data) }.must_output(/.*John Doe.*/, "")
     end
 
     context "handle ids" do
@@ -31,14 +32,14 @@ describe HammerCLI::Output::Adapter::CSValues do
       }
 
       it "should ommit column of type Id by default" do
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.wont_match(/.*Id.*/)
         out.wont_match(/.*John Doe,.*/)
       end
 
       it "should print column of type Id when --show-ids is set" do
         adapter = HammerCLI::Output::Adapter::CSValues.new( { :show_ids => true } )
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*Id.*/)
       end
     end
@@ -52,7 +53,7 @@ describe HammerCLI::Output::Adapter::CSValues do
         end
 
         adapter = HammerCLI::Output::Adapter::CSValues.new({}, { :DataField => [ DotFormatter.new ]})
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
     end

--- a/test/unit/output/adapter/table_test.rb
+++ b/test/unit/output/adapter/table_test.rb
@@ -4,22 +4,22 @@ describe HammerCLI::Output::Adapter::Table do
 
   let(:adapter) { HammerCLI::Output::Adapter::Table.new }
 
-  context "print_records" do
+  context "print_collection" do
 
     let(:field_name) { Fields::DataField.new(:path => [:name], :label => "Name") }
     let(:fields) {
       [field_name]
     }
-    let(:data) {[{
+    let(:data) { HammerCLI::Output::RecordCollection.new [{
       :name => "John Doe"
     }]}
 
-    it "should print column name" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*NAME.*/, "")
+    it "should print column name " do
+      proc { adapter.print_collection(fields, data) }.must_output(/.*NAME.*/, "")
     end
 
     it "should print field value" do
-      proc { adapter.print_records(fields, data) }.must_output(/.*John Doe.*/, "")
+      proc { adapter.print_collection(fields, data) }.must_output(/.*John Doe.*/, "")
     end
 
     context "handle ids" do
@@ -29,19 +29,19 @@ describe HammerCLI::Output::Adapter::Table do
       }
 
       it "should ommit column of type Id by default" do
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.wont_match(/.*ID.*/)
       end
 
       it "should print column of type Id when --show-ids is set" do
         adapter = HammerCLI::Output::Adapter::Table.new( { :show_ids => true } )
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*ID.*/)
       end
     end
 
     context "formatters" do
-      it "should apply formatters" do 
+      it "should apply formatters" do
         class DotFormatter < HammerCLI::Output::Formatters::FieldFormatter
           def format(data)
             '-DOT-'
@@ -49,7 +49,7 @@ describe HammerCLI::Output::Adapter::Table do
         end
 
         adapter = HammerCLI::Output::Adapter::Table.new({}, { :DataField => [ DotFormatter.new ]})
-        out, err = capture_io { adapter.print_records(fields, data) }
+        out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
     end

--- a/test/unit/output/output_test.rb
+++ b/test/unit/output/output_test.rb
@@ -53,13 +53,25 @@ describe HammerCLI::Output::Output do
     let(:collection) { [item1, item2] }
 
     it "prints single resource" do
-      adapter.any_instance.expects(:print_records).with([], [{}])
-      out.print_records(definition, item1)
+      adapter.any_instance.expects(:print_record).with([], item1)
+      out.print_record(definition, item1)
     end
 
+    it "prints single resource as collection" do
+      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection))
+      out.print_collection(definition, item1)
+    end
+
+
     it "prints array of resources" do
-      adapter.any_instance.expects(:print_records).with([], collection)
-      out.print_records(definition, collection)
+      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection))
+      out.print_collection(definition, collection)
+    end
+
+    it "prints recordset" do
+      data = HammerCLI::Output::RecordCollection.new(collection)
+      adapter.any_instance.expects(:print_collection).with([], data)
+      out.print_collection(definition, data)
     end
 
   end

--- a/test/unit/output/record_collection_test.rb
+++ b/test/unit/output/record_collection_test.rb
@@ -1,0 +1,34 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe HammerCLI::Output::RecordCollection do
+  let(:data) { [1, 2, 3] }
+  let(:meta) { { :total => 6, :page => 2, :per_page => 3, :subtotal => 5,
+          :search => 'name~=xx', :sort_by => 'name', :sort_order => 'ASC' } }
+  let(:set) { HammerCLI::Output::RecordCollection.new(data, meta) }
+
+  it "should keep records and its meta data" do
+    set.must_equal data
+    set.meta.total.must_equal 6
+    set.meta.subtotal.must_equal 5
+    set.meta.total.must_equal 6
+    set.meta.page.must_equal 2
+    set.meta.per_page.must_equal 3
+    set.meta.search.must_equal 'name~=xx'
+    set.meta.sort_by.must_equal 'name'
+    set.meta.sort_order.must_equal 'ASC'
+  end
+
+  it "should wrap the data into list" do
+    record = { :key => :value, :key2 => :value }
+    rs = HammerCLI::Output::RecordCollection.new(record)
+    rs.must_be_kind_of Array
+  end
+
+  it "sould accept MetaData as option" do
+    metadata = HammerCLI::Output::MetaData.new(meta)
+    set = HammerCLI::Output::RecordCollection.new(data, :meta => metadata)
+    set.meta.must_equal metadata
+    set.meta.total.must_equal 6
+  end
+
+end


### PR DESCRIPTION
New API v2 brings new formats for responses. This update defines unified internal data format that is used by output adapters. Each command is responsible for converting its data to this format.
