### PR TITLE
Fixed #3504 - Random column sorting on Ruby 1.8

### DIFF
--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -12,26 +12,28 @@ module HammerCLI::Output::Adapter
       print_collection(fields, [record].flatten(1))
     end
 
-    def print_collection(fields, collection)
+    def print_collection(all_fields, collection)
+
+      fields = all_fields.reject { |f| f.class <= Fields::Id && !@context[:show_ids] }
 
       rows = collection.collect do |d|
         row = {}
         fields.each do |f|
-
           row[f.label.to_sym] = f.get_value(d) || ""
         end
         row
       end
 
       options = fields.collect do |f|
-        next if f.class <= Fields::Id && !@context[:show_ids]
         { f.label.to_sym => { :formatters => Array(@formatters.formatter_for_type(f.class)) } }
       end
+
+      sort_order = fields.map { |f| f.label.upcase }
 
       printer = TablePrint::Printer.new(rows, options)
       TablePrint::Config.max_width = 40
 
-      output = printer.table_print
+      output = sort_columns(printer.table_print, sort_order)
       dashes = /\n([-|]+)\n/.match(output)
 
       puts dashes[1] if dashes
@@ -44,6 +46,42 @@ module HammerCLI::Output::Adapter
       puts '-' * size
       puts ' ' * ((size-heading.size)/2) + heading
       puts '-' * size
+    end
+
+    private
+
+    def sort_columns(output, sort_order)
+      return output if sort_order.length == 1 # don't sort one column
+      delimiter = ' | '
+      lines = output.split("\n")
+      out = []
+
+      headers = lines.first.split(delimiter).map(&:strip)
+
+      # create mapping table for column indexes
+      sort_map = []
+      sort_order.each { |c| sort_map << headers.index(c) }
+
+      lines.each do |line|
+        columns = line.split(delimiter)
+        if columns.length == 1 # dashes
+          columns = columns.first.split('-|-')
+          if columns.length == 1
+            out << columns.first
+          else # new style dashes
+            new_row = []
+            sort_map.each { |i| new_row << columns[i] }
+            out << new_row.join('-|-')
+          end
+        else
+          # reorder row
+          new_row = []
+          sort_map.each { |i| new_row << columns[i] }
+          out << new_row.join(delimiter)
+        end
+      end
+
+      out.join("\n")
     end
 
   end

--- a/test/unit/output/adapter/table_test.rb
+++ b/test/unit/output/adapter/table_test.rb
@@ -53,6 +53,25 @@ describe HammerCLI::Output::Adapter::Table do
         out.must_match(/.*-DOT-.*/)
       end
     end
+
+    context "sort_columns" do
+      let(:field_firstname) { Fields::DataField.new(:path => [:firstname], :label => "Firstname") }
+      let(:field_lastname) { Fields::DataField.new(:path => [:lastname], :label => "Lastname") }
+      let(:fields) {
+        [field_firstname, field_lastname]
+      }
+      let(:data) { HammerCLI::Output::RecordCollection.new [{
+        :firstname => "John",
+        :lastname => "Doe"
+      }]}
+
+      it "should sort output" do
+        TablePrint::Printer.any_instance.stubs(:table_print).returns(
+          "LASTNAME | FIRSTNAME\n---------|----------\nDoe      | John     \n")
+        proc { adapter.print_collection(fields, data) }.must_output(
+          "----------|---------\nFIRSTNAME | LASTNAME\n----------|---------\nJohn      | Doe     \n----------|---------\n")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Sorting columns in the _output_ from table_print seems most viable workaround so far. All more sane attempts failed.
