### PR TITLE
Bug #3893 - Avoid using git ls-files on gemspec

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
 Hammer cli provides universal extendable CLI interface for ruby apps
 EOF
 
-  s.files            = `git ls-files -- {lib,bin,doc,config,test}/* README* LICENSE hammer_cli_complete`.split("\n")
-  s.test_files       = `git ls-files -- test/*`.split("\n")
-  s.extra_rdoc_files = `git ls-files -- {doc,config}/* README*`.split("\n")
+  s.files            = Dir['{lib,test,bin,doc,config}/**/*', 'LICENSE', 'README*', 'hammer_cli_complete']
+  s.test_files       = Dir['test/**/*']
+  s.extra_rdoc_files = Dir['{doc,config}/**/*', 'README*']
   s.require_paths = ["lib"]
   s.executables = ['hammer']
 


### PR DESCRIPTION
git ls-files does not always give the right result, and installations from source might fail to build the gem properly because of this (see http://pastie.org/8557757).

See the issues below for longer discussions on this:
https://github.com/rodjek/rspec-puppet/issues/111
https://github.com/bundler/bundler/issues/2287
