### PR TITLE
Fixed #3948 - can't update user data

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -97,7 +97,9 @@ for the full list of available exit codes.
 Our new command has only one option so far. It's `-h` which is built in for every command by default.
 Option declaration is the same as in clamp so please read it's
 [documentation](https://github.com/mdub/clamp/#declaring-options)
-on that topic.
+on that topic. However unlike in Clamp, the option accessors in Hammer are created with prefix 'option_', to avoid
+conflict with methods of the commands. So to access value of an `--name` option you have to call `option_name()`
+
 
 Example option usage could go like this:
 ```ruby
@@ -106,7 +108,7 @@ class HelloCommand < HammerCLI::AbstractCommand
   option '--name', "NAME", "Name of the person you want to greet"
 
   def execute
-    print_message "Hello %s!" % (name || "World")
+    print_message "Hello %s!" % (option_name || "World")
     HammerCLI::EX_OK
   end
 end
@@ -135,20 +137,20 @@ Hammer provides extended functionality for validating options.
 First of all there is a dsl for validating combinations of options:
 ```ruby
 validate_options do
-  all(:name, :surname).required  # requires all the options
-  option(:age).required          # requires a single option,
+  all(:option_name, :option_surname).required  # requires all the options
+  option(:option_age).required          # requires a single option,
                                  # equivalent of :required => true in option declaration
-  any(:email, :phone).required   # requires at least one of the options
+  any(:option_email, :option_phone).required   # requires at least one of the options
 
   # Tt is possible to create more complicated constructs.
   # This example requires either the full address or nothing
-  if any(:street, :city, :zip).exist?
-    all(:street, :city, :zip).required
+  if any(:option_street, :option_city, :option_zip).exist?
+    all(:option_street, :option_city, :option_zip).required
   end
 
   # Here you can reject all address related option when --no-address is passed
-  if option(:no_address).exist?
-    all(:street, :city, :zip).rejected
+  if option(:option_no_address).exist?
+    all(:option_street, :option_city, :option_zip).rejected
   end
 end
 
@@ -222,7 +224,7 @@ module HammerCLIHello
       option '--name', "NAME", "Name of the person you want to greet"
 
       def execute
-        print_message "Hello %s!" % (name || "World")
+        print_message "Hello %s!" % (option_ name || "World")
         HammerCLI::EX_OK
       end
     end

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -240,6 +240,5 @@ module HammerCLI
     def options
       all_options.reject {|key, value| value.nil? }
     end
-
   end
 end

--- a/lib/hammer_cli/apipie/command.rb
+++ b/lib/hammer_cli/apipie/command.rb
@@ -15,7 +15,7 @@ module HammerCLI::Apipie
         if key.is_a? Hash
           @identifiers.merge!(key)
         else
-          @identifiers.update(key => key)
+          @identifiers.update(key => HammerCLI.option_accessor_name(key))
         end
       end
     end

--- a/lib/hammer_cli/apipie/options.rb
+++ b/lib/hammer_cli/apipie/options.rb
@@ -19,14 +19,20 @@ module HammerCLI::Apipie
       params.each do |p|
         if p["expected_type"] == "hash"
           opts[p["name"]] = method_options_for_params(p["params"], include_nil)
-        elsif respond_to?(p["name"], true)
-          opts[p["name"]] = send(p["name"])
         else
-          opts[p["name"]] = nil
+          opts[p["name"]] = get_option_value(p["name"])
         end
       end
       opts.reject! {|key, value| value.nil? } unless include_nil
       opts
+    end
+
+    def get_option_value(opt_name)
+      if respond_to?(HammerCLI.option_accessor_name(opt_name), true)
+        send(HammerCLI.option_accessor_name(opt_name))
+      else
+        nil
+      end
     end
 
     module ClassMethods

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -27,7 +27,7 @@ module HammerCLI
       :format => HammerCLI::Options::Normalizers::Bool.new,
       :context_target => :interactive
 
-    option ["--csv"], :flag, "Output as CSV (same as --adapter=csv)"
+    option ["--csv"], :flag, "Output as CSV (same as --output=csv)"
     option ["--output"], "ADAPTER", "Set output format. One of [%s]" %
       HammerCLI::Output::Output.adapters.keys.join(', '),
       :context_target => :adapter
@@ -44,7 +44,7 @@ module HammerCLI
       exit(HammerCLI::EX_OK)
     end
 
-    def csv=(csv)
+    def option_csv=(csv)
       context[:adapter] = :csv
     end
 

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -1,6 +1,19 @@
 require 'clamp'
 
 module HammerCLI
+
+  def self.option_accessor_name(*name)
+    if name.length > 1
+      name.map { |n| _option_accessor_name(n) }
+    else
+      _option_accessor_name(name.first)
+    end
+  end
+
+  def self._option_accessor_name(name)
+    "option_#{name.to_s}".gsub('-', '_')
+  end
+
   module Options
 
     class OptionDefinition < Clamp::Option::Definition
@@ -69,6 +82,12 @@ module HammerCLI
         elsif multivalued?
           []
         end
+      end
+
+      private
+
+      def infer_attribute_name
+        HammerCLI.option_accessor_name(super)
       end
 
     end

--- a/lib/hammer_cli/validator.rb
+++ b/lib/hammer_cli/validator.rb
@@ -94,7 +94,7 @@ module HammerCLI
     end
 
     def all(*to_check)
-      AllConstraint.new(@options, to_check)
+      AllConstraint.new(@options, to_check.flatten(1))
     end
 
     def option(to_check)
@@ -102,7 +102,7 @@ module HammerCLI
     end
 
     def any(*to_check)
-      AnyConstraint.new(@options, to_check)
+      AnyConstraint.new(@options, to_check.flatten(1))
     end
 
     def run(&block)

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -101,7 +101,7 @@ describe HammerCLI::AbstractCommand do
       test_command_class.option(['--password'], 'PASSWORD', 'Password')
       test_command = test_command_class.new("")
       test_command.run ['--password=pass']
-      @log_output.readline.strip.must_equal "INFO  HammerCLI::AbstractCommand : Called with options: {\"password\"=>\"***\"}"
+      @log_output.readline.strip.must_equal "INFO  HammerCLI::AbstractCommand : Called with options: {\"option_password\"=>\"***\"}"
     end
 
     class TestLogCmd < HammerCLI::AbstractCommand
@@ -282,7 +282,7 @@ describe HammerCLI::AbstractCommand do
     class CmdOD1 < HammerCLI::AbstractCommand
       output do
         label 'Label' do
-        end        
+        end
       end
     end
 

--- a/test/unit/apipie/command_test.rb
+++ b/test/unit/apipie/command_test.rb
@@ -47,35 +47,35 @@ describe HammerCLI::Apipie::Command do
       cmd_class.identifiers :id
       cmd_class.apipie_options
       option_switches.must_equal [["--id"]]
-      option_attribute_names.must_equal ["id"]
+      option_attribute_names.must_equal [HammerCLI.option_accessor_name("id")]
     end
 
     it "can set option --name" do
       cmd_class.identifiers :name
       cmd_class.apipie_options
       option_switches.must_equal [["--name"]]
-      option_attribute_names.must_equal ["name"]
+      option_attribute_names.must_equal [HammerCLI.option_accessor_name("name")]
     end
 
     it "can set option --label" do
       cmd_class.identifiers :label
       cmd_class.apipie_options
       option_switches.must_equal [["--label"]]
-      option_attribute_names.must_equal ["label"]
+      option_attribute_names.must_equal [HammerCLI.option_accessor_name("label")]
     end
 
     it "can set multiple identifiers" do
       cmd_class.identifiers :id, :name, :label
       cmd_class.apipie_options
       option_switches.must_equal [["--id"], ["--label"], ["--name"]]
-      option_attribute_names.must_equal ["id", "label", "name"]
+      option_attribute_names.must_equal HammerCLI.option_accessor_name("id", "label", "name")
     end
 
     it "can change option reader" do
-      cmd_class.identifiers :name, :id => :id_read_method
+      cmd_class.identifiers :name, :id => :option_id_read_method
       cmd_class.apipie_options
       option_switches.must_equal [["--id"], ["--name"]]
-      option_attribute_names.must_equal ["id_read_method", "name"]
+      option_attribute_names.must_equal HammerCLI.option_accessor_name("id_read_method", "name")
     end
 
     it "can override inentifiers in inherrited classes" do
@@ -176,7 +176,7 @@ describe HammerCLI::Apipie::Command do
       end
 
       it "should set correct attribute name" do
-        option.attribute_name.must_equal 'se_arch_val_ue'
+        option.attribute_name.must_equal HammerCLI.option_accessor_name('se_arch_val_ue')
       end
 
       it "should set description with html tags stripped" do
@@ -193,7 +193,7 @@ describe HammerCLI::Apipie::Command do
       let(:required_options) { cmd_class.declared_options.reject{|opt| !opt.required?} }
 
       it "should set required flag for the required options" do
-        required_options.map(&:attribute_name).sort.must_equal ["array_param"]
+        required_options.map(&:attribute_name).sort.must_equal [HammerCLI.option_accessor_name("array_param")]
       end
     end
 
@@ -204,11 +204,11 @@ describe HammerCLI::Apipie::Command do
       end
 
       it "should create options for all parameters except the hash" do
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param", "name", "provider"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal HammerCLI.option_accessor_name("array_param", "name", "provider")
       end
 
       it "should name the options correctly" do
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param", "name", "provider"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal HammerCLI.option_accessor_name("array_param", "name", "provider")
       end
     end
 
@@ -226,17 +226,17 @@ describe HammerCLI::Apipie::Command do
 
       it "should parse comma separated string to array" do
         cmd.run(["--array-param=valA,valB,valC"])
-        cmd.array_param.must_equal ['valA', 'valB', 'valC']
+        cmd.get_option_value(:array_param).must_equal ['valA', 'valB', 'valC']
       end
 
       it "should parse string to array of length 1" do
         cmd.run(["--array-param=valA"])
-        cmd.array_param.must_equal ['valA']
+        cmd.get_option_value(:array_param).must_equal ['valA']
       end
 
       it "should parse empty string to empty array" do
         cmd.run(['--array-param='])
-        cmd.array_param.must_equal []
+        cmd.get_option_value(:array_param).must_equal []
       end
 
     end
@@ -249,22 +249,22 @@ describe HammerCLI::Apipie::Command do
 
       it "should skip filtered options" do
         cmd_class.apipie_options :without => ["provider", "name"]
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal [HammerCLI.option_accessor_name("array_param")]
       end
 
       it "should skip filtered options defined as symbols" do
         cmd_class.apipie_options :without => [:provider, :name]
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal [HammerCLI.option_accessor_name("array_param")]
       end
 
       it "should skip single filtered option in array" do
         cmd_class.apipie_options :without => ["provider"]
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param", "name"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal HammerCLI.option_accessor_name("array_param", "name")
       end
 
       it "should skip single filtered option" do
         cmd_class.apipie_options :without => "provider"
-        cmd_class.declared_options.map(&:attribute_name).sort.must_equal ["array_param", "name"]
+        cmd_class.declared_options.map(&:attribute_name).sort.must_equal HammerCLI.option_accessor_name("array_param", "name")
       end
 
     end


### PR DESCRIPTION
Clamp is creating accessors for the options. While we have no control over options coming from apipie we need to prefix the accessors to avoid conflict with command's methods (password in the case of #3948)
