### PR TITLE
setting more specific range for dependency of 'mime-type' gem

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -32,6 +32,6 @@ EOF
 
   # required for ruby < 1.9.0:
   s.add_dependency 'fastercsv'             #fastercsv is default for ruby >=1.9 but it's missing in 1.8.X
-  s.add_dependency 'mime-types', '< 2.0.0' #newer versions of mime-types are not 1.8 compatible
+  s.add_dependency 'mime-types', '~> 1.25', '< 2.0' #newer versions of mime-types are not 1.8 compatible
 
 end


### PR DESCRIPTION
this fixes bundler yelling about dependencies when running `bundle install` or `bundle update` for
`hammer-cli-katello`

```
$ bundle update
Fetching gem metadata from https://rubygems.org/........
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "mime-types":
  In Gemfile:
    hammer_cli (>= 0) ruby depends on
      mime-types (< 2.0.0) ruby

    hammer_cli_katello (>= 0) ruby depends on
      mime-types (2.0)
```
