### PR TITLE
fixes #4246 - add JSONInput formalizer

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -31,6 +31,7 @@ EOF
   s.add_dependency 'highline'
 
   # required for ruby < 1.9.0:
+  s.add_dependency 'json'
   s.add_dependency 'fastercsv'             #fastercsv is default for ruby >=1.9 but it's missing in 1.8.X
   s.add_dependency 'mime-types', '~> 1.0' #newer versions of mime-types are not 1.8 compatible
 

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module HammerCLI
   module Options
     module Normalizers
@@ -88,6 +90,23 @@ module HammerCLI
             end
           end
         end
+      end
+
+      class JSONInput < File
+
+        def format(val)
+          # The JSON input can be either the path to a file whose contents are
+          # JSON or a JSON string.  For example:
+          #   /my/path/to/file.json
+          # or
+          #   '{ "units":[ { "name":"zip", "version":"9.0", "inclusion":"false" } ] }')
+          json_string = ::File.exist?(::File.expand_path(val)) ? super(val) : val
+          ::JSON.parse(json_string)
+
+        rescue ::JSON::ParserError => e
+          raise ArgumentError, "Unable to parse JSON input"
+        end
+
       end
 
 

--- a/test/unit/fixtures/json_input/invalid.json
+++ b/test/unit/fixtures/json_input/invalid.json
@@ -1,0 +1,12 @@
+{
+  units:[
+    {
+      name:zip,
+      version:10.0
+    },
+    {
+      name:zap,
+      version:9.0
+    }
+  ]
+}

--- a/test/unit/fixtures/json_input/valid.json
+++ b/test/unit/fixtures/json_input/valid.json
@@ -1,0 +1,12 @@
+{
+  "units":[
+    {
+      "name":"zip",
+      "version":"10.0"
+    },
+    {
+      "name":"zap",
+      "version":"9.0"
+    }
+  ]
+}

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -122,6 +122,33 @@ describe HammerCLI::Options::Normalizers do
     end
   end
 
+  describe 'json input' do
+    let(:formatter) { HammerCLI::Options::Normalizers::JSONInput.new }
+
+    it "should return a hash on valid json file" do
+      file = File.join(File.dirname(__FILE__), '../fixtures/json_input/valid.json')
+      formatter.format(file).must_equal({ "units" => [ { "name" => "zip", "version" => "10.0" },
+                                        { "name" => "zap", "version" => "9.0" }] })
+    end
+
+    it "should raise exception on invalid json file contents" do
+      file = File.join(File.dirname(__FILE__), '../fixtures/json_input/invalid.json')
+      proc { formatter.format(file) }.must_raise ArgumentError
+    end
+
+    it "should return a hash on valid json string" do
+      json_string = '{ "units":[{ "name":"zip", "version":"10.0" }, { "name":"zap", "version":"9.0" }] }'
+      formatter.format(json_string).must_equal({ "units" => [ { "name" => "zip", "version" => "10.0" },
+                                                              { "name" => "zap", "version" => "9.0" }] })
+    end
+
+    it "should raise exception on invalid json string" do
+      json_string = "{ units:[{ name:zip, version:10.0 }, { name:zap, version:9.0 }] }"
+      proc { formatter.format(json_string) }.must_raise ArgumentError
+    end
+
+  end
+
   describe 'enum' do
 
     let(:formatter) { HammerCLI::Options::Normalizers::Enum.new ['a', 'b'] }


### PR DESCRIPTION
Adding a formalizer that can take as input either
a json string or path to a json file.
