### PR TITLE
Fixes #4182 - completion of quoted values

### DIFF
--- a/lib/hammer_cli/shell.rb
+++ b/lib/hammer_cli/shell.rb
@@ -83,7 +83,7 @@ module HammerCLI
       ShellMainCommand.load_commands(HammerCLI::MainCommand)
 
       Readline.completion_append_character = ''
-      Readline.completer_word_break_characters = ' '
+      Readline.completer_word_break_characters = ' ='
       Readline.completion_proc = complete_proc
 
       stty_save = `stty -g`.chomp
@@ -92,12 +92,12 @@ module HammerCLI
 
       begin
         print_welcome_message
-
         while line = Readline.readline(prompt)
 
           history.push(line)
 
-          ShellMainCommand.run('', line.split, context) unless line.start_with? 'shell' or line.strip.empty?
+          line = HammerCLI::CompleterLine.new(line)
+          ShellMainCommand.run('', line, context) unless line.empty?
         end
       rescue Interrupt => e
         puts

--- a/test/unit/completer_test.rb
+++ b/test/unit/completer_test.rb
@@ -2,40 +2,198 @@ require File.join(File.dirname(__FILE__), 'test_helper')
 require 'tempfile'
 
 
-describe HammerCLI::CompleterLine do
+describe HammerCLI::CompleterWord do
 
-  let(:unfinished_line) { "architecture list --name arch" }
-  let(:finished_line) { "architecture list --name arch " }
+
+  describe "quote" do
+    it "returns empty string for empty word" do
+      word = HammerCLI::CompleterWord.new('')
+      word.quote.must_equal ""
+    end
+
+    it "returns empty string for word without quotes" do
+      word = HammerCLI::CompleterWord.new('word')
+      word.quote.must_equal ""
+    end
+
+    it "recognizes double quotes" do
+      word = HammerCLI::CompleterWord.new('"word')
+      word.quote.must_equal '"'
+    end
+
+    it "recognizes single quotes" do
+      word = HammerCLI::CompleterWord.new('\'word')
+      word.quote.must_equal "'"
+    end
+  end
+
+  describe "quoted?" do
+    it "returns false for an unquoted word" do
+      word = HammerCLI::CompleterWord.new('word')
+      word.quoted?.must_equal false
+    end
+
+    it "returns true for double quotes" do
+      word = HammerCLI::CompleterWord.new('"word')
+      word.quoted?.must_equal true
+    end
+
+    it "returns true for single quotes" do
+      word = HammerCLI::CompleterWord.new('\'word')
+      word.quoted?.must_equal true
+    end
+  end
+
+  describe "complete?" do
+    it "considers a word without quotes complete" do
+      word = HammerCLI::CompleterWord.new('word')
+      word.complete?.must_equal false
+    end
+
+    it "considers a word without quotes ending with space incomplete" do
+      word = HammerCLI::CompleterWord.new('word ')
+      word.complete?.must_equal true
+    end
+
+    it "considers open double quotes incomplete" do
+      word = HammerCLI::CompleterWord.new('"word')
+      word.complete?.must_equal false
+    end
+
+    it "considers open double quotes with spaces incomplete" do
+      word = HammerCLI::CompleterWord.new('"word ')
+      word.complete?.must_equal false
+    end
+
+    it "considers closed double quotes complete" do
+      word = HammerCLI::CompleterWord.new('"word"')
+      word.complete?.must_equal true
+    end
+
+    it "considers open single quotes incomplete" do
+      word = HammerCLI::CompleterWord.new('\'word')
+      word.complete?.must_equal false
+    end
+
+    it "considers open single quotes with spaces incomplete" do
+      word = HammerCLI::CompleterWord.new('\'word ')
+      word.complete?.must_equal false
+    end
+
+    it "considers closed single quotes complete" do
+      word = HammerCLI::CompleterWord.new('\'word\'')
+      word.complete?.must_equal true
+    end
+  end
+
+end
+
+describe HammerCLI::CompleterLine do
 
   context "splitting words" do
 
     it "should split basic line" do
-      line = HammerCLI::CompleterLine.new(finished_line)
+      line = HammerCLI::CompleterLine.new("architecture  list --name arch")
       line.must_equal ["architecture",  "list", "--name", "arch"]
     end
 
     it "should split basic line with space at the end" do
-      line = HammerCLI::CompleterLine.new(finished_line)
+      line = HammerCLI::CompleterLine.new("architecture  list --name arch  ")
       line.must_equal ["architecture",  "list", "--name", "arch"]
+    end
+
+    it "should split on equal sign" do
+      line = HammerCLI::CompleterLine.new("--name=arch")
+      line.must_equal ["--name", "arch"]
+    end
+
+    it "should split when last character is equal sign" do
+      line = HammerCLI::CompleterLine.new("--name=")
+      line.must_equal ["--name"]
+    end
+
+    it "should split on equal sign when quotes are used" do
+      line = HammerCLI::CompleterLine.new("--name='arch' ")
+      line.must_equal ["--name", "arch"]
+    end
+
+    it "should split line with single quotes" do
+      line = HammerCLI::CompleterLine.new("--name 'arch' ")
+      line.must_equal ["--name", "arch"]
+    end
+
+    it "should split line with double quotes" do
+      line = HammerCLI::CompleterLine.new("--name \"arch\"")
+      line.must_equal ["--name", "arch"]
+    end
+
+    it "should split line with single quotes and space between" do
+      line = HammerCLI::CompleterLine.new("--name 'ar ch '")
+      line.must_equal ["--name", "ar ch "]
+    end
+
+    it "should split line with one single quote and space between" do
+      line = HammerCLI::CompleterLine.new("--name 'ar ch ")
+      line.must_equal ["--name", "ar ch "]
+    end
+
+    it "should split line with double quotes and space between" do
+      line = HammerCLI::CompleterLine.new("--name \"ar ch \"")
+      line.must_equal ["--name", "ar ch "]
+    end
+
+    it "should split line with one double quote and space between" do
+      line = HammerCLI::CompleterLine.new("--name \"ar ch ")
+      line.must_equal ["--name", "ar ch "]
     end
 
   end
 
-  context "last word finished" do
+  context "line complete" do
 
-    it "should recongize unfinished line" do
-      line = HammerCLI::CompleterLine.new(unfinished_line)
-      line.finished?.must_equal false
+    it "should recongize incomplete line" do
+      line = HammerCLI::CompleterLine.new("architecture  list --name arch")
+      line.complete?.must_equal false
     end
 
-    it "should recongize finished line" do
-      line = HammerCLI::CompleterLine.new(finished_line)
-      line.finished?.must_equal true
+    it "should recongize complete line" do
+      line = HammerCLI::CompleterLine.new("architecture  list --name arch  ")
+      line.complete?.must_equal true
     end
 
-    it "should recongize empty line as finished" do
+    it "should recongize complete line that ends with quotes" do
+      line = HammerCLI::CompleterLine.new("--name 'ar ch'")
+      line.complete?.must_equal true
+    end
+
+    it "should recongize complete line that ends with quotes followed by space" do
+      line = HammerCLI::CompleterLine.new("--name 'ar ch' ")
+      line.complete?.must_equal true
+    end
+
+    it "should recongize complete line that ends with double quotes" do
+      line = HammerCLI::CompleterLine.new("--name \"ar ch\"")
+      line.complete?.must_equal true
+    end
+
+    it "should recongize one quote as incomplete" do
+      line = HammerCLI::CompleterLine.new("--name '")
+      line.complete?.must_equal false
+    end
+
+    it "should recongize one quote followed by space as incomplete" do
+      line = HammerCLI::CompleterLine.new("--name ' ")
+      line.complete?.must_equal false
+    end
+
+    it "should recongize one double quote as incomplete" do
+      line = HammerCLI::CompleterLine.new("--name \"")
+      line.complete?.must_equal false
+    end
+
+    it "should recongize empty line as complete" do
       line = HammerCLI::CompleterLine.new("")
-      line.finished?.must_equal true
+      line.complete?.must_equal true
     end
 
   end
@@ -55,7 +213,7 @@ describe HammerCLI::Completer do
       end
 
       def complete(val)
-        ["small ", "tall "]
+        ["small ", "tall ", "smel ly"]
       end
 
     end
@@ -103,6 +261,9 @@ describe HammerCLI::Completer do
   let(:completer) { HammerCLI::Completer.new(FakeMainCmd) }
 
   context "command completion" do
+
+    let(:ape_completions) { ["makkak ", "malpa ", "orangutan ", "--hairy ", "--weight ", "--height ", "-h ", "--help "] }
+
     it "should offer all available commands" do
       completer.complete("").sort.must_equal ["anabolic ", "ape ", "apocalypse ", "beast ", "-h ", "--help "].sort
     end
@@ -120,30 +281,54 @@ describe HammerCLI::Completer do
     end
 
     it "should offer all available subcommands and options" do
-      completer.complete("ape ").sort.must_equal ["makkak ", "malpa ", "orangutan ", "--hairy ", "--weight ", "--height ", "-h ", "--help "].sort
+      completer.complete("ape ").sort.must_equal ape_completions.sort
     end
 
     it "should offer all available subcommands and options even if a flag has been passed" do
-      completer.complete("ape --hairy ").sort.must_equal ["makkak ", "malpa ", "orangutan ", "--hairy ", "--weight ", "--height ", "-h ", "--help "].sort
+      completer.complete("ape --hairy ").sort.must_equal ape_completions.sort
     end
 
     it "should offer all available subcommands and options even if an option has been passed" do
-      completer.complete("ape --weight 12kg ").sort.must_equal ["makkak ", "malpa ", "orangutan ", "--hairy ", "--weight ", "--height ", "-h ", "--help "].sort
+      completer.complete("ape --weight 12kg ").sort.must_equal ape_completions.sort
     end
 
     it "should offer all available subcommands and options even if an egual sign option has been passed" do
-      completer.complete("ape --weight=12kg ").sort.must_equal ["makkak ", "malpa ", "orangutan ", "--hairy ", "--weight ", "--height ", "-h ", "--help "].sort
+      completer.complete("ape --weight=12kg ").sort.must_equal ape_completions.sort
+    end
+
+    it "should offer all available subcommands and options when quoted value was passed" do
+      completer.complete("ape --weight '12 kg' ").sort.must_equal ape_completions.sort
+    end
+
+    it "should offer all available subcommands and options when double quoted value was passed" do
+      completer.complete("ape --weight \"12 kg\" ").sort.must_equal ape_completions.sort
+    end
+
+    it "should offer all available subcommands and options when quoted value with equal sign was passed" do
+      completer.complete("ape --weight='12 kg' ").sort.must_equal ape_completions.sort
     end
   end
 
 
   context "option value completion" do
     it "should complete option values" do
-      completer.complete("ape --height ").sort.must_equal ["small ", "tall "].sort
+      completer.complete("ape --height ").sort.must_equal ["small ", "tall ", "smel ly"].sort
+    end
+
+    it "should complete option values when equal sign is used" do
+      completer.complete("ape --height=").sort.must_equal ["small ", "tall ", "smel ly"].sort
     end
 
     it "should complete option values" do
-      completer.complete("ape --height s").must_equal ["small "]
+      completer.complete("ape --height s").must_equal ["small ", "smel ly"]
+    end
+
+    it "should complete quoted option values" do
+      completer.complete("ape --height 's").must_equal ["'small' ", "'smel ly"]
+    end
+
+    it "should complete quoted option values" do
+      completer.complete("ape --height 'smel l").must_equal ["'smel ly"]
     end
   end
 


### PR DESCRIPTION
Fixes command line parsing in shell mode.
Now it accepts:
- parameters followed by equal sign  `--param=value`
- single and double quoted param values `--param 'some value'` and `--param "some value"`

Completion supports both formats above.
