### PR TITLE
fixes #4112 - cli main commands are now sorted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage
 .rvmrc
 .ruby-version
 .ruby-gemset
+
+# Editors
+tags

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -87,6 +87,19 @@ module HammerCLI
       super
     end
 
+    class SortedBuilder < Clamp::Help::Builder
+      def add_list(heading, items)
+        items.sort! do |a, b|
+          a.help[0] <=> b.help[0]
+        end
+        super(heading, items)
+      end
+    end
+
+    def help
+      self.class.help(invocation_path, SortedBuilder.new)
+    end
+
     def self.output(definition=nil, &block)
       dsl = HammerCLI::Output::Dsl.new
       dsl.build &block if block_given?


### PR DESCRIPTION
SSIA

```
[lzap@lzapx hammer-cli]$ be bin/hammer 
Usage:
    hammer [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    architecture                  Manipulate architectures.
    compute_resource              Manipulate compute resources.
    domain                        Manipulate domains.
    environment                   Manipulate environments.
    fact                          Search facts.
    global_parameter              Manipulate global parameters.
    host                          Manipulate hosts.
    hostgroup                     Manipulate hostgroups.
    location                      Manipulate locations.
    medium                        Manipulate installation media.
    model                         Manipulate hardware models.
    organization                  Manipulate organizations.
    os                            Manipulate operating system.
    partition_table               Manipulate partition tables.
    proxy                         Manipulate smart proxies.
    puppet_class                  Search puppet modules.
    report                        Browse and read reports.
    sc_param                      Manipulate smart class parameters.
    shell                         Interactive shell
    subnet                        Manipulate subnets.
    template                      Manipulate config templates.
    user                          Manipulate users.

Options:
    -v, --verbose                 be verbose
    -c, --config CFG_FILE         path to custom config file
    -u, --username USERNAME       username to access the remote system
    -p, --password PASSWORD       password to access the remote system
    --version                     show version
    --show-ids                    Show ids of associated resources
    --interactive INTERACTIVE     Explicitly turn interactive mode on/off
                                  One of true/false, yes/no, 1/0.
    --csv                         Output as CSV (same as --output=csv)
    --output ADAPTER              Set output format. One of [base, table, silent, csv]
    --csv-separator SEPARATOR     Character to separate the values
    --autocomplete LINE           Get list of possible endings
    -h, --help                    print help
```
