### PR TITLE
Defaulting label to formatted key for fields

### DIFF
--- a/lib/hammer_cli/output/dsl.rb
+++ b/lib/hammer_cli/output/dsl.rb
@@ -17,11 +17,11 @@ module HammerCLI::Output
 
     protected
 
-    def field(key, label, type=nil, options={}, &block)
+    def field(key, label=nil, type=nil, options={}, &block)
       options[:path] = current_path.clone
       options[:path] << key if !key.nil?
 
-      options[:label] = label
+      options[:label] = label || key.to_s.split("_").map(&:capitalize).join
       type ||= Fields::DataField
       custom_field type, options, &block
     end


### PR DESCRIPTION
Old way:

``` ruby
field :name, "Name"
```

New way:

``` ruby
field :id, "ID" # can still specify label if needed
field :name
```

**TODO**
- [x] Write the code
- [ ] Write tests
- [ ] Support i18n
