### PR TITLE
Changing resource name to be dashed and not just downcased

### DIFF
--- a/lib/hammer_cli/apipie/resource.rb
+++ b/lib/hammer_cli/apipie/resource.rb
@@ -9,7 +9,7 @@ module HammerCLI::Apipie
     end
 
     def name
-      resource_class.name.split("::")[-1].downcase
+      resource_class.name.split("::")[-1].dasherize
     end
 
     def plural_name

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -20,6 +20,12 @@ class String
     split('_').map{|e| e.capitalize}.join
   end
 
+  def dasherize
+    gsub(/([A-Z]+)([A-Z][a-z])/,'\1-\2').
+      gsub(/([a-z\d])([A-Z])/,'\1-\2').
+      tr("_", "-").downcase
+  end
+
 end
 
 module HammerCLI


### PR DESCRIPTION
This is to fix resource names which were 'contentview' for ContentView. It should instead be 'content-view'.

Work in progress. Need to add tests.
