### PR TITLE
add FreeBSD path for cli_config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Configuration
 Configuration is set based on the following files, loaded in this order:
 
  - ```/etc/foreman/cli_config.yml```.
+ - ```/usr/local/etc/foreman/cli_config.yml```.
  - ```~/.foreman/cli_config.yml```
  - ```./config/cli_config.yml``` (config dir in CWD)
  - custom location specified on command line - ```-c CONF_FILE_PATH```

--- a/bin/hammer
+++ b/bin/hammer
@@ -20,7 +20,7 @@ end
 # load user's settings
 require 'hammer_cli/settings'
 
-CFG_PATH = ['./config/cli_config.yml', '~/.foreman/cli_config.yml', '/etc/foreman/cli_config.yml']
+CFG_PATH = ['./config/cli_config.yml', '~/.foreman/cli_config.yml', '/usr/local/etc/foreman/cli_config.yml', '/etc/foreman/cli_config.yml']
 
 if preparser.config
   CFG_PATH.unshift preparser.config


### PR DESCRIPTION
On FreeBSD config files are in /usr/local/etc/... It would be nice if this could be applied here, so it doesn't need to be patched on FreeBSD ports.
