### PR TITLE
Fixes #3870 - add a directory for module's configs

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -30,13 +30,13 @@ end
 # load user's settings
 require 'hammer_cli/settings'
 
-CFG_PATH = ['./config/cli_config.yml', '~/.foreman/cli_config.yml', '/etc/foreman/cli_config.yml', "#{::RbConfig::CONFIG['sysconfdir']}/foreman/cli_config.yml"].uniq
+CFG_PATH = ['./config/', '~/.foreman/', '/etc/foreman/', "#{::RbConfig::CONFIG['sysconfdir']}/foreman/"].uniq
 
 if preparser.config
   CFG_PATH.unshift preparser.config
 end
 
-HammerCLI::Settings.load_from_file CFG_PATH
+HammerCLI::Settings.load_from_paths CFG_PATH
 
 # store username and password in settings
 HammerCLI::Settings.load({

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -1,13 +1,3 @@
-:modules:
-#    - hammer_cli_foreman
-#    - hammer_cli_katello
-
-:foreman:
-  :host: 'https://localhost/'
-  :username: 'admin'
-  :password: 'changeme'
-
-
 :ui:
   :interactive: true
   :per_page: 20

--- a/config/hammer.modules.d/module_config_template.yml
+++ b/config/hammer.modules.d/module_config_template.yml
@@ -1,0 +1,4 @@
+# :sample_module:
+#   :enable_module: false
+#   :some_config:   'some_value'
+

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -168,31 +168,31 @@ and optionally other plugins via any of the methods mentioned above.
 Configuration
 -------------
 
-### Format and locations
+### Locations
 
-Configuration is set based on the following files, loaded in this order:
+Configuration is by default looked for in the following directories, loaded in this order:
 
- - ```RbConfig::CONFIG['sysconfdir']/foreman/cli_config.yml``` (The actual value depends on your operatingsystem and ruby defaults.)
- - ```/etc/foreman/cli_config.yml```
- - ```~/.foreman/cli_config.yml```
- - ```./config/cli_config.yml``` (config dir in CWD)
- - custom location specified on command line - ```-c CONF_FILE_PATH```
+ - ```RbConfig::CONFIG['sysconfdir']/foreman/``` (The actual value depends on your operatingsystem and ruby defaults.)
+ - ```/etc/foreman/```
+ - ```~/.foreman/```
+ - ```./config/``` (config dir in CWD)
+ - custom location (file or directory) specified on command line - ```-c CONF_FILE_PATH```
 
-Later files have precedence if they redefines the same option.
+In each of these directories hammer is trying to load ```cli_config.yml``` and anything in
+the ```hammer.modules.d``` subdirectory which is place for specific configuration of hammer modules.
 
-Hammer uses yaml formatting for its configuration. The config file template is contained in the hammer_cli gem
+Later directories and files have precedence if they redefine the same option. Files from ```hammer.modules.d```
+are loaded in alphabetical order.
+
+### Format
+
+Hammer uses yaml formatting for its configuration. The configuration templates are contained in the hammer_cli gem
 
  ```bash
-gem contents hammer_cli|grep cli_config.template.yml
+gem contents hammer_cli|grep template.yml
 ```
 and can be copied to one of the locations above and changed as needed. The packaged version of hammer copies the template to /etc for you.
 
-
-### Plugins
-
-Plugins are disabled by default. You have to edit the config file and enable them manually under ```modules``` option, as can be seen in the sample config below.
-
-Plugin specific configuration should be nested under plugin's name.
 
 ### Options
 
@@ -201,23 +201,44 @@ Plugin specific configuration should be nested under plugin's name.
  - ```:log_owner: <owner>``` - logfile owner
  - ```:log_group: <group>``` - logfile group
  - ```:log_size: 1048576``` - size in bytes, when exceeded the log rotates. Default is 1MB
- - ```:watch_plain: false``` - turn on/off syntax highlighting of data being logged in debug mode
+ - ```:watch_plain: <bool>``` - turn on/off syntax highlighting of data being logged in debug mode
+ - ```:log_api_calls: <bool>``` - turn on logging of the communication with API (data sent and received)
 
-### Sample config
+In the ```:ui``` section there is
+
+ - ```:interactive: <bool>``` - whether to ask user for input (pagination, passwords)
+ - ```:per_page: <records>``` - number of records per page if server sends paginated data
+ - ```:history_file: <path>``` - file where the hammer shell store its history
+
+
+#### Sample config
 
 ```yaml
-:modules:
-    - hammer_cli_foreman
-    - hammer_cli_katello
+:ui:
+  :interactive: true
+  :per_page: 20
+  :history_file: '~/.foreman/history'
 
+:watch_plain: false
+
+:log_dir: '~/.foreman/log'
+:log_level: 'error'
+:log_api_calls: false
+```
+
+### Plugins
+
+Plugins are disabled by default. To enable plugin create configuration file in ```hammer.modules.d``` and add```:enable_plugin: true``` in it. Plugin specific configuration should be nested under plugin's name (without the ```hammer_cli_``` prefix).
+
+In the example we assume the gem ```hammer_cli_foreman``` with the Foreman plugin is installed. Then the plugin configuration
+in ```~/.foreman/hammer.plugins.d/foreman.yml``` should look as follows:
+
+```yaml
 :foreman:
+    :enable_module: true
     :host: 'https://localhost/'
     :username: 'admin'
     :password: 'changeme'
-
-
-:log_dir: '/var/log/foreman/'
-:log_level: 'debug'
 ```
 
 Use the hammer

--- a/lib/hammer_cli/modules.rb
+++ b/lib/hammer_cli/modules.rb
@@ -4,7 +4,22 @@ module HammerCLI
   class Modules
 
     def self.names
-      HammerCLI::Settings.get(:modules) || []
+
+      # legacy modules config
+      modules = HammerCLI::Settings.get(:modules) || []
+      logger.warn _("Legacy configuration of modules detected. Check section about configuration in user manual") unless modules.empty?
+
+      HammerCLI::Settings.dump.inject(modules) do |names, (mod_name, mod_config)|
+        if mod_config.kind_of?(Hash) && !mod_config[:enable_module].nil?
+          mod = ["hammer_cli_#{mod_name}"]
+          if mod_config[:enable_module]
+            names += mod
+          else
+            names -= mod # disable when enabled in legacy config
+          end
+        end
+        names
+      end
     end
 
     def self.find_by_name(name)

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -12,15 +12,28 @@ module HammerCLI
       end
     end
 
-    def self.load_from_file(files)
+    def self.load_from_paths(files)
       files.reverse.each do |path|
         full_path = File.expand_path path
-        if File.exists? full_path
-          config = YAML::load(File.open(full_path))
-          if config
-            load(config)
-            path_history << full_path
+        if File.file? full_path
+          load_from_file(full_path)
+        elsif File.directory? full_path
+          # check for cli_config.yml
+          load_from_file(File.join(full_path, 'cli_config.yml'))
+          # load config for modules
+          Dir.glob(File.join(full_path, 'hammer.modules.d/*.yml')).sort.each do |f|
+            load_from_file(f)
           end
+        end
+      end
+    end
+
+    def self.load_from_file(file_path)
+      if File.file? file_path
+        config = YAML::load(File.open(file_path))
+        if config
+          load(config)
+          path_history << file_path
         end
       end
     end
@@ -32,6 +45,10 @@ module HammerCLI
     def self.clear
       settings.clear
       path_history.clear
+    end
+
+    def self.dump
+      settings
     end
 
     def self.path_history

--- a/test/unit/modules_test.rb
+++ b/test/unit/modules_test.rb
@@ -18,7 +18,8 @@ describe HammerCLI::Modules do
   before :each do
     HammerCLI::Settings.clear
     HammerCLI::Settings.load({
-      :modules => ["hammer_cli_tom", "hammer_cli_jerry"]
+      :tom => { :enable_module => true },
+      :jerry => { :enable_module => true },
     })
 
     @log_output = Logging::Appenders['__test__']
@@ -27,12 +28,21 @@ describe HammerCLI::Modules do
 
   describe "names" do
     it "must return list of modules" do
-      HammerCLI::Modules.names.must_equal ["hammer_cli_tom", "hammer_cli_jerry"]
+      HammerCLI::Modules.names.sort.must_equal ["hammer_cli_tom", "hammer_cli_jerry"].sort
     end
 
     it "must return empty array by default" do
       HammerCLI::Settings.clear
       HammerCLI::Modules.names.must_equal []
+    end
+
+    it "must work with old modules config" do
+      HammerCLI::Settings.clear
+      HammerCLI::Settings.load({
+        :tom => {},
+        :modules => ['hammer_cli_tom', 'hammer_cli_jerry'],
+      })
+      HammerCLI::Modules.names.sort.must_equal ["hammer_cli_tom", "hammer_cli_jerry"].sort
     end
   end
 


### PR DESCRIPTION
With This PR hammer looks for files in  directory 'hamer.modules.d/'. One file per module. File should contain

```
:<module name>:
   :enable_module: true
```

Though not recommended old way of module configuration is still supported.
NOTE: Make sure the docs are updated and strings localized, after i18n is merged
