### PR TITLE
Fixes #4531 - subnet info in csv mode errors out

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -28,9 +28,9 @@ module HammerCLI::Output::Adapter
         collection.each do |d|
           csv << fields.inject([]) do |row, f|
             unless f.class <= Fields::Id && !@context[:show_ids]
-              value = (data_for_field(f, d) || '')
+              value = data_for_field(f, d)
               formatter = @formatters.formatter_for_type(f.class)
-              row << (formatter ? formatter.format(value) : value)
+              row << ((formatter ? formatter.format(value) : value) || '')
             end
             row
           end

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -56,6 +56,19 @@ describe HammerCLI::Output::Adapter::CSValues do
         out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
+
+      it "should not replace nil with empty string before it applies formatters" do
+        class NilFormatter < HammerCLI::Output::Formatters::FieldFormatter
+          def format(data)
+            'NIL' if data.nil?
+          end
+        end
+
+        adapter = HammerCLI::Output::Adapter::CSValues.new({}, { :Field => [ NilFormatter.new ]})
+        nil_data = HammerCLI::Output::RecordCollection.new [{ :name => nil }]
+        out, err = capture_io { adapter.print_collection([field_name], nil_data) }
+        out.must_match(/.*NIL.*/)
+      end
     end
   end
 


### PR DESCRIPTION
This issue was cause by cvs adapter converting nils to empty strings. Foreman Server formatter is sensitive to that.
To reproduce you need subnet with dns, tftp or dhcp set to nil
