### PR TITLE
fixes #4676 - numbered collections in output

### DIFF
--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -1,7 +1,7 @@
 module HammerCLI::Output::Adapter
   class Base < Abstract
 
-    GROUP_INDENT = " "*2
+    GROUP_INDENT = " "*4
     LABEL_DIVIDER = ": "
 
     def tags
@@ -56,9 +56,14 @@ module HammerCLI::Output::Adapter
       if field.is_a? Fields::ContainerField
         output = ""
 
+        idx = 0
         data = [data] unless data.is_a? Array
         data.each do |d|
-          output += render_fields(field.fields, d).indent_with(GROUP_INDENT)
+          idx += 1
+          fields_output = render_fields(field.fields, d).indent_with(GROUP_INDENT)
+          fields_output = fields_output.sub(/^[ ]{4}/, " %-3s" % "#{idx})") if field.is_a? Fields::Collection
+
+          output += fields_output
           output += "\n"
         end
 

--- a/test/unit/output/adapter/base_test.rb
+++ b/test/unit/output/adapter/base_test.rb
@@ -99,7 +99,7 @@ describe HammerCLI::Output::Adapter::Base do
 
       expected_output = [
         "Address: ",
-        "  City: New York",
+        "    City: New York",
         "\n"
       ].join("\n")
 
@@ -113,10 +113,10 @@ describe HammerCLI::Output::Adapter::Base do
 
       expected_output = [
         "Contacts: ",
-        "  Description: personal email",
-        "  Contact:     john.doe@doughnut.com",
-        "  Description: telephone",
-        "  Contact:     123456789",
+        " 1) Description: personal email",
+        "    Contact:     john.doe@doughnut.com",
+        " 2) Description: telephone",
+        "    Contact:     123456789",
         "\n"
       ].join("\n")
 
@@ -149,8 +149,8 @@ describe HammerCLI::Output::Adapter::Base do
 
       expected_output = [
         "Parameters: ",
-        "  weight => 83",
-        "  size => 32",
+        " 1) weight => 83",
+        " 2) size => 32",
         "\n"
       ].join("\n")
 


### PR DESCRIPTION
Adds numbers to collection items to make the output more readable.

Before:

```
Managed Network Interfaces:
  Id:   2
  Name: interface_1
  IP:   1.2.3.86
  MAC:  aa:bb:cc:dd:ee:33
  Id:   3
  Name: interface_2
  IP:   1.2.3.84
  MAC:  aa:bb:cc:dd:ee:11
```

After:

```
Managed Network Interfaces:
 1) Id:   2
    Name: interface_1
    IP:   1.2.3.86
    MAC:  aa:bb:cc:dd:ee:33
 2) Id:   3
    Name: interface_2
    IP:   1.2.3.84
    MAC:  aa:bb:cc:dd:ee:11
```
