### PR TITLE
Refs #3598 - bumped apipie-bindings version requirement

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -36,6 +36,6 @@ EOF
   s.add_dependency 'json'
   s.add_dependency 'fastercsv'             #fastercsv is default for ruby >=1.9 but it's missing in 1.8.X
   s.add_dependency 'mime-types', '~> 1.0'  #newer versions of mime-types are not 1.8 compatible
-  s.add_dependency 'apipie-bindings', '>= 0.0.4'
+  s.add_dependency 'apipie-bindings', '>= 0.0.6'
 
 end


### PR DESCRIPTION
apipie-bindings < 0.0.6 didn't support setting timeouts
