### PR TITLE
fixes #5605 - ignore cases where output record is null

### DIFF
--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -45,9 +45,9 @@ module HammerCLI::Output::Adapter
       path = field.path
 
       path.inject(record) do |record, path_key|
-        if record.has_key? path_key.to_sym
+        if record && record.kind_of?(Hash) && record.has_key?(path_key.to_sym)
           record[path_key.to_sym]
-        elsif record.has_key? path_key.to_s
+        elsif record && record.kind_of?(Hash) && record.has_key?(path_key.to_s)
           record[path_key.to_s]
         else
           return nil

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -93,4 +93,27 @@ describe HammerCLI::Output::Adapter::Abstract do
 
   end
 
+  context "test data_for_field" do
+    let(:field) { Fields::Field.new(:path => [:field1]) }
+
+    it "returns nil if the record is nil" do
+      record = nil
+      assert_nil adapter.send(:data_for_field, field, record)
+    end
+
+    it "returns nil if the record is not a hash" do
+      record = []
+      assert_nil adapter.send(:data_for_field, field, record)
+    end
+
+    it "returns nil, if the data does not exist for the field" do
+      record = { :field2 => :value2 }
+      assert_nil adapter.send(:data_for_field, field, record)
+    end
+
+    it "returns the value, if data exists for the field" do
+      record = { :field1 => :value1, :field2 => :value2 }
+      assert_equal adapter.send(:data_for_field, field, record), :value1
+    end
+  end
 end


### PR DESCRIPTION
This commit is to address a case that we observed with
a couple of the hammer-cli-katello commands.

E.g.
command 'activation-key list' has the following output
defined:

```
    from :environment do
      field :name, _("Lifecycle Environment")
    end
    from :content_view do
      field :name, _("Content View")
    end
```

Since environment and content_view are optional, there
are cases where this would result in a 'null' back
from the server for those entities.  When that occurs
the following error would be generated to the user:

Error: undefined method `has_key?' for nil:NilClass

This small change addresses that error.
