### PR TITLE
Fixes #5822 - Wrong width of table columns with formatters

### DIFF
--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -38,14 +38,14 @@ module HammerCLI::Output::Adapter
       rows = collection.collect do |d|
         row = {}
         fields.each do |f|
-          row[label_for(f)] = data_for_field(f, d) || ""
+          row[label_for(f)] = WrapperFormatter.new(
+            @formatters.formatter_for_type(f.class), f.parameters).format(data_for_field(f, d) || "")
         end
         row
       end
 
       options = fields.collect do |f|
         { label_for(f) => {
-            :formatters => Array(WrapperFormatter.new(@formatters.formatter_for_type(f.class), f.parameters)),
             :width => max_width_for(f)
           }
         }

--- a/test/unit/output/adapter/table_test.rb
+++ b/test/unit/output/adapter/table_test.rb
@@ -9,6 +9,7 @@ describe HammerCLI::Output::Adapter::Table do
     let(:field_name) { Fields::Field.new(:path => [:fullname], :label => "Name") }
     let(:field_firstname) { Fields::Field.new(:path => [:firstname], :label => "Firstname") }
     let(:field_lastname) { Fields::Field.new(:path => [:lastname], :label => "Lastname") }
+    let(:field_long) { Fields::Field.new(:path => [:long], :label => "Full") }
 
     let(:fields) {
       [field_name]
@@ -128,6 +129,28 @@ describe HammerCLI::Output::Adapter::Table do
         out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
+
+      it "should not break formatting" do
+        class SliceFormatter < HammerCLI::Output::Formatters::FieldFormatter
+          def format(data, field_params={})
+            data[0..5]
+          end
+        end
+
+        adapter = HammerCLI::Output::Adapter::Table.new({}, { :Field => [ SliceFormatter.new ]})
+
+        expected_output = [
+          "------",
+          "FULL  ",
+          "------",
+          "SomeVe",
+          "------",
+          ""
+        ].join("\n")
+
+        proc { adapter.print_collection([field_long], data) }.must_output(expected_output)
+      end
+
     end
 
     context "sort_columns" do


### PR DESCRIPTION
This issue caused ugly formatting of tables with columns containing formatters. 
e.g. `hammer hostgroup list`. 

The formatters are now applied in the hammer instead of letting this on table_print
