### PR TITLE
Fixes #5111 - CSV handles collection or container

### DIFF
--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -41,7 +41,7 @@ module HammerCLI::Output::Adapter
       HammerCLI::Output::FieldFilter.new
     end
 
-    def data_for_field(field, record)
+    def self.data_for_field(field, record)
       path = field.path
 
       path.inject(record) do |record, path_key|
@@ -53,6 +53,10 @@ module HammerCLI::Output::Adapter
           return nil
         end
       end
+    end
+
+    def data_for_field(field, record)
+      Abstract.data_for_field(field, record)
     end
 
     private

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -16,13 +16,16 @@ describe HammerCLI::Output::Adapter::CSValues do
       :started_at => "2000"
     }]}
 
-
     it "should print column name" do
-      proc { adapter.print_collection(fields, data) }.must_output(/.*Name,Started At.*/, "")
+      out, err = capture_io { adapter.print_collection(fields, data) }
+      out.must_match /.*Name,Started At.*/
+      err.must_match //
     end
 
     it "should print field value" do
-      proc { adapter.print_collection(fields, data) }.must_output(/.*John Doe.*/, "")
+      out, err = capture_io { adapter.print_collection(fields, data) }
+      out.must_match /.*John Doe.*/
+      err.must_match //
     end
 
     context "handle ids" do
@@ -30,17 +33,105 @@ describe HammerCLI::Output::Adapter::CSValues do
       let(:fields) {
         [field_name, field_id]
       }
+      let(:data) { HammerCLI::Output::RecordCollection.new [{
+        :name => "John Doe",
+        :some_id => "2000"
+      }]}
 
       it "should ommit column of type Id by default" do
         out, err = capture_io { adapter.print_collection(fields, data) }
         out.wont_match(/.*Id.*/)
-        out.wont_match(/.*John Doe,.*/)
+        out.wont_match(/.*2000,.*/)
       end
 
       it "should print column of type Id when --show-ids is set" do
         adapter = HammerCLI::Output::Adapter::CSValues.new( { :show_ids => true } )
         out, err = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*Id.*/)
+      end
+    end
+
+    context "handle fields with containers" do
+      let(:demographics) {
+        Fields::Label.new(:path => [], :label => "Demographics") do
+          from :demographics do
+            field :age, "Age"
+            field :gender, "Gender"
+            label _("Biometrics") do
+              from :biometrics do
+                field :weight, "Weight"
+                field :height, "Height"
+              end
+            end
+          end
+        end
+      }
+      let(:fields) {
+        [field_name, field_started_at, demographics]
+      }
+      let(:data) { HammerCLI::Output::RecordCollection.new [{
+        :name => "John Doe",
+        :started_at => "2000",
+        :demographics=> { :age => '22', :gender => 'm',
+                          :biometrics => { :weight => '123', :height => '155' } }
+      }]}
+
+      it "should print column names" do
+        out, err = capture_io { adapter.print_collection(fields, data) }
+        out.must_match /.*Demographics::Age,Demographics::Gender,Biometrics::Weight,Biometrics::Height*/
+        err.must_match //
+      end
+
+      it "should print data" do
+        out, err = capture_io { adapter.print_collection(fields, data) }
+        out.must_match /.*2000,22,m,123,155*/
+        err.must_match //
+      end
+    end
+
+    context "handle fields with collections" do
+      let(:items) {
+        Fields::Collection.new(:path => [:items], :label => "Items") do
+          from :item do
+            field :name, "Item Name"
+            field :quantity, "Item Quantity"
+          end
+        end
+      }
+      let(:fields) {
+        [field_name, field_started_at, items]
+      }
+      let(:data) { HammerCLI::Output::RecordCollection.new [
+        {
+          :name => "John Doe",
+          :started_at => "2000",
+          :items => [{:item => { :name => 'hammer', :quantity => '100'}}]
+        },
+        {
+          :name => "Jane Roe",
+          :started_at => "2001",
+          :items => [{:item => { :name => 'cleaver', :quantity => '1'}}, {:item => { :name => 'sledge', :quantity => '50'}}]
+        }
+      ]}
+
+      it "should print collection column name" do
+        adapter.print_collection(fields, data)
+        out, err = capture_io { adapter.print_collection(fields, data) }
+
+        lines = out.split("\n")
+        lines[0].must_equal 'Name,Started At,Items::Item Name::1,Items::Item Quantity::1,Items::Item Name::2,Items::Item Quantity::2'
+
+        err.must_match //
+      end
+
+      it "should print collection data" do
+        out, err = capture_io { adapter.print_collection(fields, data) }
+        lines = out.split("\n")
+
+        lines[1].must_equal 'John Doe,2000,hammer,100,"",""'
+        lines[2].must_equal 'Jane Roe,2001,cleaver,1,sledge,50'
+
+        err.must_match //
       end
     end
 


### PR DESCRIPTION
csv adapter was not processing fields of collections or containers correctly:
For fields that are collections or containers, a ruby hash  is the result for that column.
Example from `hammer --output csv product info`: https://gist.github.com/dustint-rh/1b1edb08396256d54fe7

This fix creates columns for the nested fields in collection and container in the csv.

if the output definition specifies container:

```
        label _("GPG") do
          from :gpg_key do
            field :id, _("GPG Key ID")
            field :name, _("GPG Key")
          end
        end 
```

both GPG Key Id and GPG Key will be columns in the csv.

if the output definition specifies a collection:

```
       collection :productContent, _("Content") do
          from :content do
            field :name, _("Repo Name")
            field :contentUrl, _("URL")
          end
        end
```

a pair of fields will be displayed for each productContent.

Here is a sample of the output produced by this pull request: https://gist.github.com/dustint-rh/9b0eb6a0456ac4e960b6
