### PR TITLE
refs #5793 - add pkg:generate_source task to generate gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,3 +22,8 @@ namespace :gettext do
   end
 
 end
+
+namespace :pkg do
+  desc 'Generate package source gem'
+  task :generate_source => :build
+end


### PR DESCRIPTION
Same principle as https://github.com/theforeman/smart-proxy/pull/159, to give us a single command across our projects that will produce a source file to feed into nightly RPMs & debs.
