### PR TITLE
Fixes #6238 - empty list in csv adapter does not work

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -150,9 +150,12 @@ module HammerCLI::Output::Adapter
 
     def print_collection(fields, collection)
       rows = row_data(fields, collection)
+      # get headers using columns heuristic
       headers = rows.map{ |r| Cell.headers(r, @context) }.max_by{ |headers| headers.size }
+      # or use headers from output definition
+      headers ||= default_headers(fields)
       csv_string = generate do |csv|
-        csv << headers
+        csv << headers if headers
         rows.each do |row|
           csv << Cell.values(headers, row)
         end
@@ -192,6 +195,10 @@ module HammerCLI::Output::Adapter
         :encoding => 'utf-8',
         &block
       )
+    end
+
+    def default_headers(fields)
+      fields.select{ |f| !(f.class <= Fields::Id) || @context[:show_ids] }.map { |f| f.label }
     end
 
   end

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -115,7 +115,6 @@ describe HammerCLI::Output::Adapter::CSValues do
       ]}
 
       it "should print collection column name" do
-        adapter.print_collection(fields, data)
         out, err = capture_io { adapter.print_collection(fields, data) }
 
         lines = out.split("\n")
@@ -133,6 +132,16 @@ describe HammerCLI::Output::Adapter::CSValues do
 
         err.must_match //
       end
+
+      it "should handle empty collection" do
+        out, err = capture_io { adapter.print_collection(fields, []) }
+        lines = out.split("\n")
+
+        lines[0].must_equal 'Name,Started At,Items'
+
+        err.must_match //
+      end
+
     end
 
     context "formatters" do


### PR DESCRIPTION
The csv adapter should print the headers on empty list
