### PR TITLE
Fixes #4162 - native readline replaced with rb-readline

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -34,6 +34,7 @@ EOF
 
   # required for ruby < 1.9.0:
   s.add_dependency 'json'
+  s.add_dependency 'rb-readline'           #original readline is missing method 'line_buffer' in 1.8
   s.add_dependency 'fastercsv'             #fastercsv is default for ruby >=1.9 but it's missing in 1.8.X
   s.add_dependency 'mime-types', '~> 1.0'  #newer versions of mime-types are not 1.8 compatible
   s.add_dependency 'apipie-bindings', '>= 0.0.8'

--- a/lib/hammer_cli/shell.rb
+++ b/lib/hammer_cli/shell.rb
@@ -82,13 +82,9 @@ module HammerCLI
     def execute
       ShellMainCommand.load_commands(HammerCLI::MainCommand)
 
-      if RUBY_VERSION >= "1.9"
-        Readline.completion_append_character = ''
-        Readline.completer_word_break_characters = ' ='
-        Readline.completion_proc = complete_proc
-      else
-        Readline.completion_proc = lambda {}
-      end
+      Readline.completion_append_character = ''
+      Readline.completer_word_break_characters = ' ='
+      Readline.completion_proc = complete_proc
 
       stty_save = `stty -g`.chomp
 
@@ -119,7 +115,6 @@ module HammerCLI
     def print_welcome_message
       print_message(_("Welcome to the hammer interactive shell"))
       print_message(_("Type 'help' for usage information"))
-      print_message(_("Command completion is disabled on ruby < 1.9 due to compatibility problems.")) if RUBY_VERSION < "1.9"
     end
 
     def common_prefix(results)


### PR DESCRIPTION
Please test with ruby versions 1.8, 1.9 and 2.0
