### PR TITLE
i18n - fix apipie warning string to be properly extracted

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -83,3 +83,18 @@ puts _("Hello %s, it is %s" % [name, day])
 # CORRECT
 puts _("Hello %{name}, it is %{day}") % {:name => name, :day => day}
 ```
+
+
+3) Don't use newlines in the gettext function. Strings with newlines are not extracted correctly.
+```ruby
+# WRONG
+puts _("TODO: \n - make dishes\n - do shopping")
+# CORRECT
+puts _("TODO:") +
+     "\n - " + _("make dishes") +
+     "\n - " + _("do shopping")
+```
+
+
+4) Try setting `:mark_translated: true` to identify gaps in your translations.
+This will wrap all translated strings with angle brackets '>message<'.

--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -63,7 +63,8 @@ module HammerCLI
     end
 
     def handle_usage_exception(e)
-      print_error _("Error: %{message}\n\nSee: '%{path} --help'") % {:message => e.message, :path => e.command.invocation_path}
+      print_error (_("Error: %{message}") + "\n\n" +
+                   _("See: '%{path} --help'")) % {:message => e.message, :path => e.command.invocation_path}
       log_full_error e
       HammerCLI::EX_USAGE
     end


### PR DESCRIPTION
I can't get "\n" to really work properly with gettext, I'd suggest always ensuring it's outside of strings.  I think the gettext extraction isn't as good as the Rails one we use in core Foreman.
