### PR TITLE
i18n - add mark_translated to highlight extracted strings

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -60,6 +60,10 @@ HammerCLI::Settings.load({
     :verbose => preparser.verbose? || preparser.debug?
   }})
 
+if HammerCLI::Settings.get(:mark_translated)
+  include HammerCLI::I18n::Debug
+end
+
 # setup logging
 require 'hammer_cli/logger'
 logger = Logging.logger['Init']

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -22,3 +22,6 @@
 
 # Maximum log size in bytes. Log rotates when the value gets exceeded
 #:log_size: 5 #in MB
+
+# Mark translated strings with X characters (for developers)
+#:mark_translated: false

--- a/lib/hammer_cli/i18n.rb
+++ b/lib/hammer_cli/i18n.rb
@@ -22,6 +22,47 @@ module HammerCLI
       end
     end
 
+    # include this module to see translations highlighted
+    module Debug
+      DL = '>'
+      DR = '<'
+
+      # slightly modified copy of fast_gettext D_* method
+      def _(key)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.d_(domain, key) {nil}
+          return DL + result + DR unless result.nil?
+        end
+        DL + key + DR
+      end
+
+      # slightly modified copy of fast_gettext D_* method
+      def n_(*keys)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.dn_(domain, *keys) {nil}
+          return DL + result + DR unless result.nil?
+        end
+        DL + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last + DR
+      end
+
+      # slightly modified copy of fast_gettext D_* method
+      def s_(key, separator=nil)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) {nil}
+          return DL + result + DR unless result.nil?
+        end
+        DL + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last + DR
+      end
+
+      # slightly modified copy of fast_gettext D_* method
+      def ns_(*keys)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.dns_(domain, *keys) {nil}
+          return DL + result + DR unless result.nil?
+        end
+        DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last + DR
+      end
+    end
 
     class AbstractLocaleDomain
 


### PR DESCRIPTION
I didn't have much luck using Unicode as per Foreman, as table_print got confused and messed up the layout.  Strangely, it was better with its "better" multibyte option disabled, but that's probably not best.
