### PR TITLE
Fixes #7144 - add/remove content-hosts fails

### DIFF
--- a/lib/hammer_cli/apipie/option_builder.rb
+++ b/lib/hammer_cli/apipie/option_builder.rb
@@ -59,9 +59,9 @@ module HammerCLI::Apipie
     def option_opts(param)
       opts = {}
       opts[:required] = true if (param.required? and require_options?)
-      # FIXME: There is a bug in apipie, it does not produce correct expected type for Arrays
-      # When it's fixed, we should test param["expected_type"] == "array"
-      opts[:format] = HammerCLI::Options::Normalizers::List.new if param.validator.include? "Array"
+      if param.expected_type == :array || param.validator =~ /Array/i
+        opts[:format] = HammerCLI::Options::Normalizers::List.new
+      end
       opts[:attribute_name] = HammerCLI.option_accessor_name(param.name)
       return opts
     end

--- a/test/unit/fixtures/apipie/documented.json
+++ b/test/unit/fixtures/apipie/documented.json
@@ -54,7 +54,7 @@
                                 "allow_null": false,
                                 "full_name": "organization_ids",
                                 "validator": "Array of numbers",
-                                "expected_type": "Array",
+                                "expected_type": "array",
                                 "description": "",
                                 "required": false
                             },
@@ -107,7 +107,7 @@
                                         "allow_null": false,
                                         "full_name": "documented[array_param]",
                                         "validator": "Must be Array",
-                                        "expected_type": "string",
+                                        "expected_type": "array",
                                         "description": "",
                                         "required": true
                                     }


### PR DESCRIPTION
--content-host-ids is not being treated as an array and is
therefore being sent incorrectly through apipie. This correctly
treats params as array options by checking expected_type
