### PR TITLE
fixes #7284 - display optional for options that are not required

### DIFF
--- a/lib/hammer_cli/apipie/command.rb
+++ b/lib/hammer_cli/apipie/command.rb
@@ -20,7 +20,7 @@ module HammerCLI::Apipie
     def self.create_option_builder
       builder = super
       builder.builders += [
-        OptionBuilder.new(resource.action(action), :require_options => false)
+        OptionBuilder.new(resource.action(action), :require_options => true)
       ] if resource_defined?
       builder
     end

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -36,7 +36,7 @@ module HammerCLI
       end
 
       def help_lhs
-        super
+        @required ? super : "#{super} (optional)"
       end
 
       def help_rhs

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -47,6 +47,7 @@ describe HammerCLI::Apipie::OptionBuilder do
 
     let(:action) {api.resource(:documented).action(:create)}
     let(:required_options) { builder.build.reject{|opt| !opt.required?} }
+    let(:optional_options) { builder.build.reject{|opt| opt.required?} }
 
     it "should set required flag for the required options" do
       required_options.map(&:attribute_name).sort.must_equal [HammerCLI.option_accessor_name("array_param")]
@@ -55,6 +56,12 @@ describe HammerCLI::Apipie::OptionBuilder do
     it "should not require any option when requirements are disabled" do
       builder.require_options = false
       required_options.map(&:attribute_name).sort.must_equal []
+    end
+
+    it "should state optional if option is not required" do
+      optional_options.each do |o|
+        o.help_lhs.include? "optional"
+      end
     end
   end
 


### PR DESCRIPTION
Display "optional" next to options that are not required.
