### PR TITLE
Fixes #7408 - Credentials interface definition moved to ApipieBindings

### DIFF
--- a/lib/hammer_cli/apipie/resource.rb
+++ b/lib/hammer_cli/apipie/resource.rb
@@ -1,36 +1,14 @@
 require 'apipie_bindings'
 module HammerCLI::Apipie
 
-  class AbstractCredentials
-
-    def to_params
-      {}
-    end
-
-    private
-
-    def ask_user(prompt, silent=false)
-      if silent
-        ask(prompt) {|q| q.echo = false}
-      else
-        ask(prompt)
-      end
-    end
-
-  end
-
 
   class ApipieConnector < HammerCLI::AbstractConnector
 
     attr_reader :api
 
     def initialize(params)
-      credentials = params.delete(:credentials)
-      params.merge!(credentials.to_params) if credentials
-
       @api = ApipieBindings::API.new(params)
     end
-
   end
 
 


### PR DESCRIPTION
DO NOT MERGE before https://github.com/Apipie/apipie-bindings/pull/20 is released and dependency on apipie_bindings is bumped
