### PR TITLE
Fixes #8430 - Add option forcing apipie cache reload

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -17,6 +17,7 @@ class PreParser < Clamp::Command
   option ["-u", "--username"], "USERNAME", _("username to access the remote system")
   option ["-p", "--password"], "PASSWORD", _("password to access the remote system")
   option ["-s", "--server"], "SERVER", _("remote system address")
+  option ["-r", "--reload-cache"], :flag, _("force reload of Apipie cache")
   option ["--interactive"], "INTERACTIVE", _("Explicitly turn interactive mode on/off") do |value|
     bool_normalizer = HammerCLI::Options::Normalizers::Bool.new
     bool_normalizer.format(value)
@@ -57,7 +58,8 @@ HammerCLI::Settings.load({
     :password => preparser.password,
     :host => preparser.server,
     :interactive => preparser.interactive,
-    :verbose => preparser.verbose? || preparser.debug?
+    :verbose => preparser.verbose? || preparser.debug?,
+    :reload_cache => preparser.reload_cache?
   }})
 
 if HammerCLI::Settings.get(:mark_translated)

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -11,6 +11,9 @@
 # Enable/disable color output of logger in Clamp commands
 :watch_plain: false
 
+# Forece relaod of Apipie cache with every Hammer invocation
+:reload_cache: false
+
 # Directory where the logs are stored. The default is /var/log/hammer/ and the log file is named hammer.log
 :log_dir: '~/.hammer/log'
 

--- a/lib/hammer_cli/apipie/resource.rb
+++ b/lib/hammer_cli/apipie/resource.rb
@@ -8,6 +8,10 @@ module HammerCLI::Apipie
 
     def initialize(params)
       @api = ApipieBindings::API.new(params)
+      if HammerCLI::Settings.get(:_params, :reload_cache) || HammerCLI::Settings.get(:reload_cache)
+        @api.clean_cache
+        Logging.logger['Init'].debug 'Apipie cache was cleared'
+      end
     end
   end
 

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -6,6 +6,8 @@ module HammerCLI
 
     option ["-v", "--verbose"], :flag, _("be verbose"), :context_target => :verbose
     option ["-d", "--debug"], :flag, _("show debugging output "), :context_target => :debug
+    option ["-r", "--reload-cache"], :flag, _("force reload of Apipie cache")
+
     option ["-c", "--config"], "CFG_FILE", _("path to custom config file")
 
     option ["-u", "--username"], "USERNAME", _("username to access the remote system"),

--- a/test/unit/apipie/command_test.rb
+++ b/test/unit/apipie/command_test.rb
@@ -113,6 +113,28 @@ describe HammerCLI::Apipie::Command do
     it "should perform a call to api when resource is defined" do
       cmd_run.must_equal 0
     end
+  end
+
+  context "reload apipie cache" do
+
+    before :each do
+      HammerCLI::Connection.drop_all
+      ApipieBindings::API.any_instance.stubs(:call).returns([])
+    end
+
+    it "clears the cache on init when required from config" do
+      HammerCLI::Settings.load({ :reload_cache => true })
+      ApipieBindings::API.any_instance.expects(:clean_cache).returns(nil)
+      cmd.class.resource :architectures, :index
+      HammerCLI::Settings.load({ :reload_cache => false })
+    end
+
+    it "clears the cache on init when required from CLI" do
+      HammerCLI::Settings.load({ :_params => { :reload_cache => true }})
+      ApipieBindings::API.any_instance.expects(:clean_cache).returns(nil)
+      cmd.class.resource :architectures, :index
+      HammerCLI::Settings.load({ :_params => { :reload_cache => false }})
+    end
 
   end
 


### PR DESCRIPTION
Trigger the reload of the cache either from cli with `-r`, `--reload-cache`  or from cli_config.yml with `:reload_cache: true`
The cache removal is indicated in the logs, look for  `Apipie cache was cleared`
