### PR TITLE
fixes #8569 - hammer-cli CSV formatter doesn't properly format values

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -37,8 +37,9 @@ module HammerCLI::Output::Adapter
       end
 
       def formatted_value
-        formatter = @formatters.formatter_for_type(@field_wrapper.field.class)
-        formatter ? formatter.format(value) : value.to_s
+        WrapperFormatter.new(
+            @formatters.formatter_for_type(@field_wrapper.field.class),
+            @field_wrapper.field.parameters).format(value)
       end
 
       def self.values(headers, cells)


### PR DESCRIPTION
with custom formatters, moving to correct implementation
(this uses the same implementation as in Table, which does things right.
