### PR TITLE
Refs #8569 - csv formatter should not replace nil

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -41,7 +41,7 @@ module HammerCLI::Output::Adapter
       def formatted_value
         WrapperFormatter.new(
             @formatters.formatter_for_type(@field_wrapper.field.class),
-            @field_wrapper.field.parameters).format(value || "")
+            @field_wrapper.field.parameters).format(value)
       end
 
       def self.values(headers, cells)


### PR DESCRIPTION
Csv formatter should not replace nil with empty string before it applies
formatters.
