### PR TITLE
fixes #8980 - update to gettext 3.x, unpin locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ coverage
 
 # Editors
 tags
+
+# Locale files
+locale/*/*.edit.po
+locale/*/*.po.time_stamp

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [foreman.hammer-cli]
-file_filter = locale/<lang>/hammer-cli.po
+file_filter = locale/<lang>/hammer-cli.edit.po
 source_file = locale/hammer-cli.pot
 source_lang = en
 type = PO

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,10 @@ source "http://rubygems.org"
 
 gemspec
 
-# for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-gem 'gettext', '~> 2.0'
+if RUBY_VERSION >= '1.9'
+  # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
+  gem 'gettext', '>= 3.1.3', '< 4.0.0'
+end
 
 group :test do
   gem 'rake', '~> 10.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -11,14 +11,25 @@ end
 
 namespace :gettext do
 
-  desc "Update pot file"
-  task :find do
+  task :setup do
     require "hammer_cli/version"
     require "hammer_cli/i18n"
-    require 'gettext/tools'
+    require 'gettext/tools/task'
 
     domain = HammerCLI::I18n::LocaleDomain.new
-    GetText.update_pofiles(domain.domain_name, domain.translated_files, "#{domain.domain_name} #{HammerCLI.version.to_s}", :po_root => domain.locale_dir)
+    GetText::Tools::Task.define do |task|
+      task.package_name = domain.domain_name
+      task.package_version = HammerCLI.version.dup
+      task.domain = domain.domain_name
+      task.mo_base_directory = domain.locale_dir
+      task.po_base_directory = domain.locale_dir
+      task.files = domain.translated_files
+    end
+  end
+
+  desc "Update pot file"
+  task :find => [:setup] do
+    Rake::Task["gettext:po:update"].invoke
   end
 
 end

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -30,7 +30,7 @@ EOF
   s.add_dependency 'table_print'
   s.add_dependency 'highline'
   s.add_dependency 'fast_gettext'
-  s.add_dependency 'locale', '<= 2.0.9'
+  s.add_dependency 'locale'
 
   # required for ruby < 1.9.0:
   s.add_dependency 'json'

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -10,9 +10,10 @@ DOMAIN = hammer-cli
 VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load("../hammer_cli.gemspec");puts spec.version')
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
-POFILES = $(shell find . -name '*.po')
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
 	mkdir -p $(shell dirname $@)/LC_MESSAGES
@@ -30,13 +31,6 @@ all-mo: $(MOFILES)
 	! grep -q msgid $@
 
 check: $(POXFILES)
-	msgfmt -c ${POTFILE}
-
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
 
 # Unify duplicate translations
 uniq-po:
@@ -44,22 +38,20 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-tx-pull:
+tx-pull: $(EDITFILES)
 	tx pull -f
 	for f in $(POFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done
-	-git commit -a -m "i18n - extracting new, pulling from tx"
 
+# Extract strings and update the .pot, prepare .edit.po files
 extract-strings:
 	bundle exec rake gettext:find
 
-reset-po:
-	# merging po files is unnecessary when using transifex.com
-	git checkout -- ../locale/*/*po
+# Merge .edit.po into .po
+update-po:
+	bundle exec rake gettext:find
 
-tx-update: tx-pull extract-strings reset-po $(MOFILES)
-	# amend mo files
-	git add ../locale/*/LC_MESSAGES
-	git commit -a --amend -m "i18n - extracting new, pulling from tx"
+tx-update: extract-strings tx-pull $(MOFILES)
+	git commit -m "i18n - extracting new, pulling from tx" ../locale
 	-echo Changes commited!


### PR DESCRIPTION
3.1.13 adds an intermediate .edit.po file alongside each .po, which is meant
to be kept outside of SCM and updated by users, whereupon it's merged back into
the .po on the next rake gettext:find execution.

Previously we overwrote all gettext .po file changes with files directly from
Transifex, but now these are downloaded to .edit.po and gettext merges them
back in.

---

I'll do the same for hammer-cli-foreman if this is accepted, should be a copy/paste job.

This restricts handling po updates to Ruby 1.9, but I don't think that's a big deal.  It means we can deal with newer versions of locale at runtime.

This mirrors the core update (https://github.com/theforeman/foreman/pull/2096) which is a bit stuck on plugin support.