### PR TITLE
Fixes #9721 - ignore spaces in key value formatting

### DIFF
--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -32,7 +32,7 @@ module HammerCLI
 
           result = {}
 
-          pair_re = '([^,]+)=([^,\[]+|\[[^\[\]]*\])'
+          pair_re = '([^,=]+)=([^,\[]+|\[[^\[\]]*\])'
           full_re = "^((%s)[,]?)+$" % pair_re
 
           unless Regexp.new(full_re).match(val)
@@ -43,10 +43,26 @@ module HammerCLI
             value = value.strip
             value = value.scan(/[^,\[\]]+/) if value.start_with?('[')
 
-            result[key.strip]=value
+            result[key.strip] = strip_value(value)
           end
           return result
+        end
 
+        private
+
+        def strip_value(value)
+          if value.is_a? Array
+            value.map do |item|
+              strip_chars(item.strip, '"\'')
+            end
+          else
+            strip_chars(value.strip, '"\'')
+          end
+        end
+
+        def strip_chars(string, chars)
+          chars = Regexp.escape(chars)
+          string.gsub(/\A[#{chars}]+|[#{chars}]+\z/, '')
         end
       end
 

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -56,8 +56,36 @@ describe HammerCLI::Options::Normalizers do
       formatter.format("a=1,b=2,c=3").must_equal({'a' => '1', 'b' => '2', 'c' => '3'})
     end
 
+    it "should parse a comma separated string with spaces" do
+      formatter.format("a= 1 , b = 2 ,c =3").must_equal({'a' => '1', 'b' => '2', 'c' => '3'})
+    end
+
+    it "should parse a comma separated string with spaces using single quotes" do
+      formatter.format("a= ' 1 ' , b =' 2',c ='3'").must_equal({'a' => ' 1 ', 'b' => ' 2', 'c' => '3'})
+    end
+
+    it "should parse a comma separated string with spaces using double quotes" do
+      formatter.format("a= \" 1 \" , b =\" 2\",c =\"3\"").must_equal({'a' => ' 1 ', 'b' => ' 2', 'c' => '3'})
+    end
+
+    it "should deal with equal sign in value" do
+      formatter.format("a=1,b='2=2',c=3").must_equal({'a' => '1', 'b' => '2=2', 'c' => '3'})
+    end
+
     it "should parse arrays" do
       formatter.format("a=1,b=[1,2,3],c=3").must_equal({'a' => '1', 'b' => ['1', '2', '3'], 'c' => '3'})
+    end
+
+    it "should parse arrays with spaces" do
+      formatter.format("a=1,b=[1, 2, 3],c=3").must_equal({'a' => '1', 'b' => ['1', '2', '3'], 'c' => '3'})
+    end
+
+    it "should parse arrays with spaces using by single quotes" do
+      formatter.format("a=1,b=['1 1', ' 2 ', ' 3 3'],c=3").must_equal({'a' => '1', 'b' => ['1 1', ' 2 ', ' 3 3'], 'c' => '3'})
+    end
+
+    it "should parse arrays with spaces using by double quotes" do
+      formatter.format("a=1,b=[\"1 1\", \" 2 \", \" 3 3\"],c=3").must_equal({'a' => '1', 'b' => ['1 1', ' 2 ', ' 3 3'], 'c' => '3'})
     end
 
     it "should parse array with one item" do


### PR DESCRIPTION
Updates key-value format to ignore spaces unless they are explicitly
enclosed with quotes. Some examples of input and results of parsing
below:

```
--params "key=[ value1, value2 ]"
{'key' => ['value1', 'value2']}
```
```
--params "key=' value with spaces '"
{'key' => ' value with spaces '}
```