### PR TITLE
Fixes #9742 - version fails with error

### DIFF
--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -20,7 +20,7 @@ module HammerCLI
     option "--version", :flag, _("show version") do
       puts "hammer (%s)" % HammerCLI.version
       HammerCLI::Modules.names.each do |m|
-        module_version = HammerCLI::Modules.find_by_name(m).version
+        module_version = HammerCLI::Modules.find_by_name(m).version rescue _("unknown version")
         puts " * #{m} (#{module_version})"
       end
       exit(HammerCLI::EX_OK)


### PR DESCRIPTION
`hammer --version` could fail with "undefined method 'version'" exception when hammer was configured to use plugin that doesn't define `version`.