### PR TITLE
require clamp >=1.0.0

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -23,7 +23,7 @@ EOF
   s.require_paths = ["lib"]
   s.executables = ['hammer']
 
-  s.add_dependency 'clamp'
+  s.add_dependency 'clamp', '>= 1.0.0'
   s.add_dependency 'rest-client', '< 1.7.0' #higher versions are not ruby 1.8 compatible
   s.add_dependency 'logging', '< 2.0.0' #higher versions are not ruby 1.8 compatible
   s.add_dependency 'awesome_print'


### PR DESCRIPTION
as i18n is available since 1.0.0 in the upstream gem.