### PR TITLE
refs #11280 - drop Ruby 1.8 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,14 @@ source "https://rubygems.org"
 
 gemspec
 
-if RUBY_VERSION >= '1.9'
-  # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
-  gem 'gettext', '>= 3.1.3', '< 4.0.0'
-end
+gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 group :test do
   gem 'rake', '~> 10.1.0'
   gem 'thor'
   gem 'minitest', '4.7.4'
   gem 'minitest-spec-context'
-  gem 'simplecov', '< 0.9.0' # 0.9.0 is not compatible with Ruby 1.8.x
+  gem 'simplecov'
   gem 'mocha'
   gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
 end

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -25,18 +25,12 @@ EOF
 
   s.add_dependency 'clamp', '>= 1.0.0'
   s.add_dependency 'rest-client', '< 1.7.0' #higher versions are not ruby 1.8 compatible
-  s.add_dependency 'logging', '< 2.0.0' #higher versions are not ruby 1.8 compatible
+  s.add_dependency 'logging'
   s.add_dependency 'awesome_print'
   s.add_dependency 'table_print'
-  s.add_dependency 'highline', '< 1.7.0' #higher versions are not ruby 1.8 compatible
+  s.add_dependency 'highline'
   s.add_dependency 'fast_gettext'
   s.add_dependency 'locale', '>= 2.0.6'
-
-  # required for ruby < 1.9.0:
-  s.add_dependency 'json'
-  s.add_dependency 'rb-readline'           #original readline is missing method 'line_buffer' in 1.8
-  s.add_dependency 'fastercsv'             #fastercsv is default for ruby >=1.9 but it's missing in 1.8.X
-  s.add_dependency 'mime-types', '~> 1.0'  #newer versions of mime-types are not 1.8 compatible
   s.add_dependency 'apipie-bindings', '~> 0.0.10'
 
 end


### PR DESCRIPTION
I did leave rest-client untouched for now, as 1.7 does verify_ssl by default.
I'm unsure about the major version bump of logging, but at least an error got logged as expected with 2.0.0 in my tests.

Discuss! :boom: 