### PR TITLE
Fixes #7534 - Add filtering of the logs

### DIFF
--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -30,9 +30,7 @@ module HammerCLI
     def parse(arguments)
       super
       validate_options
-      safe_options = options.dup
-      safe_options.keys.each { |k| safe_options[k] = '***' if k.end_with?('password') }
-      logger.info "Called with options: %s" % safe_options.inspect
+      logger.info "Called with options: %s" % options.inspect
     rescue HammerCLI::Validator::ValidationError => e
       signal_usage_error e.message
     end

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -1,0 +1,18 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'tempfile'
+
+describe Logging::LogEvent do
+  context "filtering" do
+    before :each do
+      @log_output = Logging::Appenders['__test__']
+      @log_output.reset
+    end
+
+    it "can filter log data" do
+      Logging::LogEvent.add_data_filter(/pat/, 'mat')
+      Logging.logger.root.debug "pat"
+      Logging::LogEvent.data_filters.pop # clean the last filter
+      @log_output.read.must_include 'mat'
+    end
+  end
+end

--- a/test/unit/test_helper.rb
+++ b/test/unit/test_helper.rb
@@ -8,13 +8,13 @@ SimpleCov.start do
 end
 SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
 
-
 require 'minitest/autorun'
 require 'minitest/spec'
 require "minitest-spec-context"
 require "mocha/setup"
 
 require 'hammer_cli'
+require 'hammer_cli/logger'
 
 Logging.logger.root.appenders = Logging::Appenders['__test__'] || Logging::Appenders::StringIo.new('__test__')
 


### PR DESCRIPTION
Ability to filter the data with simple gsub was added in LogEvent (Logging internal object representing the data being logged). LogEvent class can hold list of `pattern`, `replacement` pairs that are applied one by one. The list can be extended with 
```ruby
Logging::LogEvent.add_data_filter(/foo/, 'bar')
```

Existing filtering of password arguments was replaced.
Tests were updated accordingly.