### PR TITLE
Fixes #12751 - --plugin-name renamed to --provider

### DIFF
--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -15,7 +15,7 @@ module HammerCLI
     end
 
     def register_provider(provider)
-      providers[provider.plugin_name.to_s] = provider
+      providers[provider.provider_name.to_s] = provider
     end
 
     def providers

--- a/test/unit/defaults_test.rb
+++ b/test/unit/defaults_test.rb
@@ -31,7 +31,7 @@ describe HammerCLI::Defaults do
 
   it "should get the default param, with provider" do
     fake_provider = mock()
-    fake_provider.stubs(:plugin_name).returns(:foreman)
+    fake_provider.stubs(:provider_name).returns(:foreman)
     fake_provider.expects(:get_defaults).with(:organization_id).returns(3)
     @defaults.register_provider(fake_provider)
     assert_equal 3, @defaults.get_defaults("organization_id")


### PR DESCRIPTION
- renamed option in `defaults add`
- fixed minor formatting issues
- fixed plugin/provider inconsistencies in the code
- removed default provider_name

I propose removal of the provider default name generated from the plugin name. The reason is that there is no relation between the provider name  and the plugin name. I'd prefer one plugin to offer rather more simplier defaults providers then one complex provider. E.g. foreman plugin could implement `taxonomies` provider providing orgs and locations. 

It would be nice to add description to the provider and print it in `defaults providers` so that the user knows what is it good for. What do you think? @alongoldboim, @tstrachota 