### PR TITLE
Fixes #13525: Allows loading module configs from config/

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -42,6 +42,13 @@ end
 # load user's settings
 require 'hammer_cli/settings'
 
+hammer_gems = Gem::Specification.select do |spec|
+  spec.name.include?('hammer_cli')
+end
+CFG_PATH_GEM = hammer_gems.collect { |spec| "#{spec.gem_dir}/config" }
+
+HammerCLI::Settings.load_from_paths CFG_PATH_GEM
+
 CFG_PATH_LEGACY = ['~/.foreman/', '/etc/foreman/', "#{::RbConfig::CONFIG['sysconfdir']}/foreman/"].uniq
 HammerCLI::Settings.load_from_paths CFG_PATH_LEGACY
 if HammerCLI::Settings.path_history.empty?

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -20,7 +20,7 @@ module HammerCLI
           load_from_file(File.join(full_path, 'cli_config.yml'))
           load_from_file(File.join(full_path, 'defaults.yml'))
           # load config for modules
-          Dir.glob(File.join(full_path, 'cli.modules.d/*.yml')).sort.each do |f|
+          Dir.glob(File.join(full_path, '**/*.yml')).sort.each do |f|
             load_from_file(f)
           end
           Dir.glob(File.join(full_path, 'hammer.modules.d/*.yml')).sort.each do |f|


### PR DESCRIPTION
Hammer has an expecatation that module configuration exists in
cli.modules.d and typically from the system configuration directory
or user configuration directory. If a user wants to install hammer
or a module via 'gem install' the modules aren't available by default.
Most modules put their default configuration into <module>/config/<module>.yml
which won't be loaded by default. This change allows gem install of
any module and automatic usage of hammer and any modules that are
enabled by default.
