### PR TITLE
Fixes #12797 - remove psych require from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
-gem 'psych' # requiring psych to workaround issues with bundler 1.11.0, see https://github.com/bundler/bundler/issues/4149
 
 group :test do
   gem 'rake', '~> 10.1.0'


### PR DESCRIPTION
It was used only as a workaroud for a bundler issue that has been fixed.