### PR TITLE
Fixes #13960 - Fix coded options for apipie 0.3.6

### DIFF
--- a/lib/hammer_cli/apipie/option_builder.rb
+++ b/lib/hammer_cli/apipie/option_builder.rb
@@ -69,7 +69,8 @@ module HammerCLI::Apipie
       elsif param.expected_type == 'boolean' || param.validator =~ /Boolean/i
         opts[:format] = HammerCLI::Options::Normalizers::Bool.new
       elsif param.validator =~ /Must be one of: (.*)\./
-        opts[:format] = HammerCLI::Options::Normalizers::Enum.new($1.split(/,\ ?/))
+        allowed = $1.split(/,\ ?/).map { |val| val.gsub(/<[^>]*>/i,'') }
+        opts[:format] = HammerCLI::Options::Normalizers::Enum.new(allowed)
       elsif param.expected_type == 'number' || param.validator =~ /Number/i
         opts[:format] = HammerCLI::Options::Normalizers::Number.new
       end

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -91,6 +91,12 @@ describe HammerCLI::Apipie::OptionBuilder do
       enum_option.value_formatter.allowed_values.sort.must_equal ["one", "two", "three"].sort
     end
 
+    it "should set enum normalizer and handle coded values" do
+      enum_option = options.find {|o| o.attribute_name == HammerCLI.option_accessor_name("coded_enum_param") }
+      enum_option.value_formatter.class.must_equal HammerCLI::Options::Normalizers::Enum
+      enum_option.value_formatter.allowed_values.sort.must_equal ["tomas", "tereza"].sort
+    end
+
     it "should set number normalizer" do
       numeric_option = options.find {|o| o.attribute_name == HammerCLI.option_accessor_name("numeric_param") }
       numeric_option.value_formatter.class.must_equal HammerCLI::Options::Normalizers::Number

--- a/test/unit/fixtures/apipie/documented.json
+++ b/test/unit/fixtures/apipie/documented.json
@@ -149,6 +149,15 @@
                                 "required": false
                             },
                             {
+                                "name": "coded_enum_param",
+                                "full_name": "documented[coded_enum_param]",
+                                "allow_nil": true,
+                                "validator": "Must be one of: <code>tomas</code>, <code>tereza</code>.",
+                                "expected_type": "string",
+                                "description": "",
+                                "required": false
+                            },
+                            {
                                 "name": "numeric_param",
                                 "allow_null": false,
                                 "full_name": "documented[numeric_param]",


### PR DESCRIPTION
As of 0.3.6 of apipie-rails, options are now surrounded in code tags. This adds support for that. More info:

https://github.com/Apipie/apipie-rails/pull/426