### PR TITLE
Fixes #14092 -  gettext speed improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
+if RUBY_VERSION < '2.1.0'
+  gem 'fast_gettext', '< 1.2.0'
+end
+
 
 group :test do
   gem 'rake', '~> 10.1.0'

--- a/bin/hammer
+++ b/bin/hammer
@@ -79,7 +79,7 @@ HammerCLI::Settings.load({
     :reload_cache => preparser.reload_cache?
   }})
 
-if HammerCLI::Settings.get(:mark_translated)
+if HammerCLI::Settings.get(:ui, :mark_translated)
   include HammerCLI::I18n::Debug
 end
 

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -28,7 +28,7 @@ EOF
   s.add_dependency 'awesome_print'
   s.add_dependency 'table_print'
   s.add_dependency 'highline'
-  s.add_dependency 'fast_gettext'
+  s.add_dependency 'fast_gettext', '>= 1.2.0'
   s.add_dependency 'locale', '>= 2.0.6'
   s.add_dependency 'apipie-bindings', '~> 0.0.14'
 

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -28,7 +28,7 @@ EOF
   s.add_dependency 'awesome_print'
   s.add_dependency 'table_print'
   s.add_dependency 'highline'
-  s.add_dependency 'fast_gettext', '>= 1.2.0'
+  s.add_dependency 'fast_gettext'
   s.add_dependency 'locale', '>= 2.0.6'
   s.add_dependency 'apipie-bindings', '~> 0.0.14'
 

--- a/lib/hammer_cli/i18n.rb
+++ b/lib/hammer_cli/i18n.rb
@@ -4,68 +4,40 @@ require 'locale'
 module HammerCLI
   module I18n
 
-    module AllDomains
-      def _(key)
-        FastGettext::TranslationMultidomain.D_(key)
-      end
-
-      def n_(*keys)
-        FastGettext::TranslationMultidomain.Dn_(*keys)
-      end
-
-      def s_(key, separator=nil)
-        FastGettext::TranslationMultidomain.Ds_(key, separator)
-      end
-
-      def ns_(*keys)
-        FastGettext::TranslationMultidomain.Dns_(*keys)
-      end
-    end
+    TEXT_DOMAIN = 'hammer-cli'
 
     # include this module to see translations highlighted
     module Debug
       DL = '>'
       DR = '<'
 
-      # slightly modified copy of fast_gettext D_* method
+      # slightly modified copy of fast_gettext _ method
       def _(key)
-        FastGettext.translation_repositories.each_key do |domain|
-          result = FastGettext::TranslationMultidomain.d_(domain, key) {nil}
-          return DL + result + DR unless result.nil?
-        end
-        DL + key + DR
+        _wrap { FastGettext::Translation._(key) }
       end
 
-      # slightly modified copy of fast_gettext D_* method
+      # slightly modified copy of fast_gettext n_ method
       def n_(*keys)
-        FastGettext.translation_repositories.each_key do |domain|
-          result = FastGettext::TranslationMultidomain.dn_(domain, *keys) {nil}
-          return DL + result + DR unless result.nil?
-        end
-        DL + keys[-3].split(keys[-2]||FastGettext::NAMESPACE_SEPARATOR).last + DR
+        _wrap { FastGettext::Translation.n_(*keys) }
       end
 
-      # slightly modified copy of fast_gettext D_* method
-      def s_(key, separator=nil)
-        FastGettext.translation_repositories.each_key do |domain|
-          result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) {nil}
-          return DL + result + DR unless result.nil?
-        end
-        DL + key.split(separator||FastGettext::NAMESPACE_SEPARATOR).last + DR
+      # slightly modified copy of fast_gettext s_ method
+      def s_(key, separator=nil, &block)
+        _wrap { FastGettext::Translation.s_(key, separator, &block) }
       end
 
-      # slightly modified copy of fast_gettext D_* method
-      def ns_(*keys)
-        FastGettext.translation_repositories.each_key do |domain|
-          result = FastGettext::TranslationMultidomain.dns_(domain, *keys) {nil}
-          return DL + result + DR unless result.nil?
-        end
-        DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last + DR
+      # slightly modified copy of fast_gettext ns_ method
+      def ns_(*args, &block)
+        _wrap { FastGettext::Translation.ns_(*args, &block) }
+      end
+
+      def _wrap(&block)
+        result = yield
+        DL + result + DR unless result.nil?
       end
     end
 
     class AbstractLocaleDomain
-
       def available_locales
         Dir.glob(locale_dir+'/*').select { |f| File.directory? f }.map { |f| File.basename(f) }
       end
@@ -87,7 +59,6 @@ module HammerCLI
 
 
     class LocaleDomain < AbstractLocaleDomain
-
       def translated_files
         Dir.glob(File.join(File.dirname(__FILE__), '../**/*.rb'))
       end
@@ -99,17 +70,13 @@ module HammerCLI
       def domain_name
         'hammer-cli'
       end
-
     end
 
     class SystemLocaleDomain < LocaleDomain
-
       def locale_dir
         '/usr/share/locale'
       end
-
     end
-
 
     def self.locale
       lang_variant = Locale.current.to_simple.to_str
@@ -123,34 +90,40 @@ module HammerCLI
       end
     end
 
-
     def self.domains
       @domains ||= []
       @domains
     end
 
-
     def self.add_domain(domain)
       if domain.available?
         domains << domain
-        FastGettext.add_text_domain(domain.domain_name, :path => domain.locale_dir, :type => domain.type, :report_warning => false)
+        translation_repository.add_repo(build_repository(domain))
       end
     end
 
+    def self.build_repository(domain)
+      FastGettext::TranslationRepository.build(domain.domain_name, :path => domain.locale_dir, :type => domain.type, :report_warning => false)
+    end
 
     def self.clear
-      FastGettext.translation_repositories.clear
+      translation_repository.clear
       domains.clear
+    end
+
+    def self.translation_repository
+      FastGettext.translation_repositories[HammerCLI::I18n::TEXT_DOMAIN] ||= FastGettext::TranslationRepository.build(HammerCLI::I18n::TEXT_DOMAIN, :type => :merge)
     end
 
     Encoding.default_external='UTF-8' if defined? Encoding
     FastGettext.locale = locale
-
+    FastGettext.text_domain = HammerCLI::I18n::TEXT_DOMAIN
   end
 end
 
 include FastGettext::Translation
-include HammerCLI::I18n::AllDomains
+
 
 domain = [HammerCLI::I18n::LocaleDomain.new, HammerCLI::I18n::SystemLocaleDomain.new].find { |d| d.available? }
 HammerCLI::I18n.add_domain(domain) if domain
+

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -14,10 +14,6 @@ describe HammerCLI::Apipie::OptionBuilder do
     })
   end
 
-  before :each do
-    HammerCLI::I18n.clear
-  end
-
   let(:resource) {api.resource(:documented)}
   let(:action) {resource.action(:index)}
   let(:builder) { HammerCLI::Apipie::OptionBuilder.new(resource, action) }

--- a/test/unit/i18n_test.rb
+++ b/test/unit/i18n_test.rb
@@ -32,9 +32,13 @@ describe HammerCLI::I18n do
   let(:unavailable_domain) { TestLocaleDomain.new('domain3', false) }
 
   it "registers available domains at gettext" do
-    FastGettext.expects(:add_text_domain).with do |name, options|
-      (name == domain1.domain_name) && (options[:path] == domain1.locale_dir) && (options[:type] == domain1.type)
-    end
+    repo = mock
+    FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
+      :path => domain1.locale_dir,
+      :type => domain1.type,
+      :report_warning => false).returns(repo)
+
+    HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
     HammerCLI::I18n.add_domain(domain1)
   end
 

--- a/test/unit/i18n_test.rb
+++ b/test/unit/i18n_test.rb
@@ -23,32 +23,74 @@ describe HammerCLI::I18n do
     end
   end
 
-  before :each do
-    HammerCLI::I18n.clear
+  let(:fast_gettext_version) { '1.2.0' }
+
+  before do
+    @domains_backup ||= HammerCLI::I18n.domains.dup
+    HammerCLI::I18n.stubs(:fast_gettext_version).returns(fast_gettext_version)
+    HammerCLI::I18n.init
+  end
+
+  after do
+    mocha_teardown
+    HammerCLI::I18n.init(@domains_backup)
   end
 
   let(:domain1) { TestLocaleDomain.new('domain1', true) }
   let(:domain2) { TestLocaleDomain.new('domain2', true) }
   let(:unavailable_domain) { TestLocaleDomain.new('domain3', false) }
 
-  it "registers available domains at gettext" do
-    repo = mock
-    FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
-      :path => domain1.locale_dir,
-      :type => domain1.type,
-      :report_warning => false).returns(repo)
+  # skip the tests on older versions of fast_gettext (ruby 2.0)
+  if FastGettext::VERSION >= '1.2.0'
+    describe "with fast_gettext >= 1.2.0" do
+      it "creates base merge repository" do
+        HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Merge
+      end
 
-    HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
-    HammerCLI::I18n.add_domain(domain1)
+      it "registers available domains at gettext" do
+        repo = mock
+        FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
+          :path => domain1.locale_dir,
+          :type => domain1.type,
+          :report_warning => false).returns(repo)
+
+        HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
+        HammerCLI::I18n.add_domain(domain1)
+      end
+
+      it "skips registering domains that are not available" do
+        HammerCLI::I18n.add_domain(domain1)
+        HammerCLI::I18n.add_domain(domain2)
+        HammerCLI::I18n.add_domain(unavailable_domain)
+        HammerCLI::I18n.domains.must_equal [domain1, domain2]
+      end
+    end
   end
 
-  it "skips registering domains that are not available" do
-    HammerCLI::I18n.add_domain(domain1)
-    HammerCLI::I18n.add_domain(domain2)
-    HammerCLI::I18n.add_domain(unavailable_domain)
-    HammerCLI::I18n.domains.must_equal [domain1, domain2]
+  describe "with fast_gettext < 1.2.0" do
+    let(:fast_gettext_version) { '1.1.0' }
+
+    it "creates base chain repository" do
+      HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Chain
+    end
+
+    it "registers available domains at gettext" do
+      repo = mock
+      FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
+        :path => domain1.locale_dir,
+        :type => domain1.type,
+        :report_warning => false).returns(repo)
+
+      HammerCLI::I18n.translation_repository.chain.expects(:<<).with(repo)
+      HammerCLI::I18n.add_domain(domain1)
+    end
+
+    it "skips registering domains that are not available" do
+      HammerCLI::I18n.add_domain(domain1)
+      HammerCLI::I18n.add_domain(domain2)
+      HammerCLI::I18n.add_domain(unavailable_domain)
+      HammerCLI::I18n.domains.must_equal [domain1, domain2]
+    end
   end
-
-
 end
 


### PR DESCRIPTION
Fixes fast-gettext performance issues in multidomain mode:
* multiple domains replaced by a translation repository that merges subrepositories
* .mo files are loaded lazily
* translation api for plugins remains the same

Please compare hammer speed with and without this patch when it's configured with multiple plugins.