### PR TITLE
Refs #14530 - Add pagination info when incomplete data are received

### DIFF
--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -57,6 +57,11 @@ module HammerCLI::Output::Adapter
       puts dashes[1] if dashes
       puts output
       puts dashes[1] if dashes
+
+      if collection.meta.pagination_set? && collection.count < collection.meta.subtotal
+        pages = (collection.meta.subtotal.to_f/collection.meta.per_page).ceil
+        puts _("Page #{collection.meta.page} of #{pages} (use --page and --per-page for navigation)")
+      end
     end
 
     protected

--- a/lib/hammer_cli/output/record_collection.rb
+++ b/lib/hammer_cli/output/record_collection.rb
@@ -6,13 +6,17 @@ module HammerCLI::Output
     attr_accessor :total, :subtotal, :page, :per_page, :search, :sort_by, :sort_order
 
     def initialize(options={})
-      @total = options[:total]
-      @subtotal = options[:subtotal]
-      @page = options[:page]
-      @per_page = options[:per_page]
+      @total = options[:total].to_i if options[:total]
+      @subtotal = options[:subtotal].to_i if options[:subtotal]
+      @page = options[:page].to_i if options[:page]
+      @per_page = options[:per_page].to_i if options[:per_page]
       @search = options[:search]
       @sort_by = options[:sort_by]
       @sort_order = options[:sort_order]
+    end
+
+    def pagination_set?
+      !(@total.nil? || @subtotal.nil? || @page.nil? || @per_page.nil?)
     end
 
   end

--- a/test/unit/output/adapter/table_test.rb
+++ b/test/unit/output/adapter/table_test.rb
@@ -15,14 +15,14 @@ describe HammerCLI::Output::Adapter::Table do
       [field_name]
     }
 
-    let(:data) { HammerCLI::Output::RecordCollection.new [{
+    let(:record) { {
       :id => 1,
       :firstname => "John",
       :lastname => "Doe",
       :fullname => "John Doe",
       :long => "SomeVeryLongString"
-    }]}
-
+    } }
+    let(:data) { HammerCLI::Output::RecordCollection.new [record] }
     let(:empty_data) { HammerCLI::Output::RecordCollection.new [] }
 
     it "should print column name " do
@@ -31,6 +31,18 @@ describe HammerCLI::Output::Adapter::Table do
 
     it "should print field value" do
       proc { adapter.print_collection(fields, data) }.must_output(/.*John Doe.*/, "")
+    end
+
+    context "pagination" do
+      it "should print pagination info if data are not complete" do
+        data = HammerCLI::Output::RecordCollection.new([record], { :total => 2, :page => 1, :per_page => 1, :subtotal => 2 })
+        proc { adapter.print_collection(fields, data) }.must_output(/.*Page 1 of 2 (use --page and --per-page for navigation)*/, "")
+      end
+
+      it "should print pagination info if data are complete" do
+        data = HammerCLI::Output::RecordCollection.new([record], { :total => 1, :page => 1, :per_page => 1, :subtotal => 1 })
+        proc { adapter.print_collection(fields, data) }.must_output("--------\nNAME    \n--------\nJohn Doe\n--------\n", "")
+      end
     end
 
     context "handle ids" do

--- a/test/unit/output/record_collection_test.rb
+++ b/test/unit/output/record_collection_test.rb
@@ -30,5 +30,31 @@ describe HammerCLI::Output::RecordCollection do
     set.meta.must_equal metadata
     set.meta.total.must_equal 6
   end
+end
 
+describe HammerCLI::Output::MetaData do
+
+  let(:meta) { HammerCLI::Output::MetaData.new(:total => "6", :page => "2", :per_page => "3", :subtotal => "5") }
+
+  it "converts numeric metadata to numbers" do
+    meta.total.must_equal 6
+    meta.page.must_equal 2
+    meta.per_page.must_equal 3
+    meta.subtotal.must_equal 5
+  end
+
+  describe "pagination_set?" do
+    let(:pagination_data) { { :total => 6, :page => 2, :per_page => 3, :subtotal => 5 } }
+
+    it "can tell if pagination data are set" do
+      meta.pagination_set?.must_equal true
+    end
+
+    it "can tell if pagination data are not set" do
+      pagination_data.keys.each do |key|
+        meta = HammerCLI::Output::MetaData.new(pagination_data.clone.reject { |k| k == key })
+        meta.pagination_set?.must_equal false
+      end
+    end
+  end
 end


### PR DESCRIPTION
It is hard to tell if the data received are complete or not especially if we can set per_page with defaults and config file. This patch is adding info about current page and number of pages when applicable.

```
$ hammer  template list --per-page 5
---|----------------------------|----------
ID | NAME                       | TYPE     
---|----------------------------|----------
7  | Alterator default          | provision
8  | Alterator default finish   | finish   
9  | Alterator default PXELinux | PXELinux 
41 | alterator_pkglist          | snippet  
10 | Atomic Kickstart default   | provision
---|----------------------------|----------
Page 1 of 13 (use --page and --per-page for navigation)
```