### PR TITLE
Fixes #14591 - Introduced log format setting

### DIFF
--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -28,3 +28,6 @@
 
 # Mark translated strings with X characters (for developers)
 #:mark_translated: false
+
+# Log record pattern (logging gem syntax)
+#:log_pattern: '[%5l %d %c] %m'

--- a/lib/hammer_cli/logger.rb
+++ b/lib/hammer_cli/logger.rb
@@ -45,7 +45,7 @@ module HammerCLI
                          :file   => :yellow,
                          :method => :yellow)
 
-    pattern         = "[%5l %d %c] %m\n"
+    pattern         = "#{HammerCLI::Settings.get(:log_pattern) || '[%5l %d %c] %m'}\n"
     COLOR_LAYOUT    = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => 'bright')
     NOCOLOR_LAYOUT  = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => nil)
     DEFAULT_LOG_DIR = '/var/log/hammer'


### PR DESCRIPTION
By default the log format is wide, I prefer shorter format for development
purposes.