### PR TITLE
Refs #8015 - allow param names to contain dashes

### DIFF
--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -23,27 +23,24 @@ module HammerCLI
     end
 
     def delete_default_from_conf(param)
-      conf_file = YAML.load_file(path)
-      conf_file[:defaults].delete_if { |k,| k.to_s.gsub('-','_') == param.to_s.gsub('-','_') }
-      write_to_file conf_file
-      conf_file
+      update_defaults_file do |defaults|
+        defaults.delete_if { |k,| defaults_match?(k, param) }
+      end
     end
 
     def add_defaults_to_conf(default_options, provider)
       create_default_file if defaults_settings.empty?
-      defaults = YAML.load_file(path)
-      defaults[:defaults] ||= {}
-      default_options.each do |key, value|
-        key = key.to_sym
-        defaults[:defaults].delete_if { |k,| k.to_s.gsub('-','_') == key.to_s.gsub('-','_') }
-        defaults[:defaults][key] = (value ? {:value => value,} : {:provider => provider})
+      update_defaults_file do |defaults|
+        default_options.each do |key, value|
+          key = key.to_sym
+          defaults.delete_if { |k,| defaults_match?(k, key) }
+          defaults[key] = (value ? {:value => value,} : {:provider => provider})
+        end
       end
-      write_to_file defaults
-      defaults
     end
 
     def defaults_set?(param)
-      defaults_settings.keys.any? { |k| k.to_s.gsub('-','_') == param.to_s.gsub('-','_') }
+      defaults_settings.keys.any? { |k| defaults_match?(k, param) }
     end
 
     def get_defaults(opt)
@@ -79,6 +76,20 @@ module HammerCLI
       else
         raise DefaultsPathError.new(_("Couldn't create %s please create the path before defaults are enabled.") % path)
       end
+    end
+
+    def update_defaults_file
+      conf_file = YAML.load_file(@path)
+      conf_file[:defaults] ||= {}
+      yield conf_file[:defaults]
+      write_to_file conf_file
+      conf_file
+    end
+
+    private
+
+    def defaults_match?(default_a, default_b)
+      default_a.to_s.gsub('-','_') == default_b.to_s.gsub('-','_')
     end
   end
 

--- a/lib/hammer_cli/defaults_commands.rb
+++ b/lib/hammer_cli/defaults_commands.rb
@@ -87,7 +87,7 @@ module HammerCLI
       option "--param-name", "OPTION_NAME", _("The name of the default option"), :required => true
 
       def execute
-        if context[:defaults].defaults_settings && context[:defaults].defaults_settings[option_param_name.to_sym]
+        if context[:defaults] && context[:defaults].defaults_set?(option_param_name)
           context[:defaults].delete_default_from_conf(option_param_name.to_sym)
           param_deleted(option_param_name)
         else
@@ -115,7 +115,7 @@ module HammerCLI
             if !context[:defaults].providers.key?(namespace)
               provider_prob_message(namespace)
               return HammerCLI::EX_USAGE
-            elsif !context[:defaults].providers[namespace].param_supported?(option_param_name)
+            elsif !context[:defaults].providers[namespace].param_supported?(option_param_name.gsub('-','_'))
               defaults_not_supported_by_provider
               return HammerCLI::EX_CONFIG
             end

--- a/test/functional/defaults_test.rb
+++ b/test/functional/defaults_test.rb
@@ -118,6 +118,18 @@ describe 'commands' do
       assert_cmd(expected_result, result)
     end
 
+    it 'adds default from provider with name with dashed' do
+      options = ['--param-name=organization-id', '--provider=foreman']
+
+      @defaults.expects(:add_defaults_to_conf).with({'organization-id' => nil}, 'foreman').once
+
+      expected_result = success_result("Added organization-id default-option with value that will be generated from the server.\n")
+
+      result = run_cmd(cmd + options, @context)
+      assert_cmd(expected_result, result)
+    end
+
+
     it 'reports unsupported option' do
       options = ['--param-name=unsupported', '--provider=foreman']
       expected_result = success_result("The param name is not supported by provider. See `hammer defaults providers` for supported params.\n")

--- a/test/unit/defaults_test.rb
+++ b/test/unit/defaults_test.rb
@@ -1,44 +1,106 @@
 require File.join(File.dirname(__FILE__), 'test_helper')
 describe HammerCLI::Defaults do
 
-  FILEPATH = File.join(File.dirname(__FILE__), '/fixtures/defaults/defaults.yml')
+  let(:filepath) { File.join(File.dirname(__FILE__), '/fixtures/defaults/defaults.yml') }
 
   before(:all) do
-    settings = YAML::load(File.open(FILEPATH))
+    settings = YAML::load(File.open(filepath))
 
-    @defaults = HammerCLI::Defaults.new(settings[:defaults], FILEPATH)
+    @defaults = HammerCLI::Defaults.new(settings[:defaults], filepath)
     @defaults.stubs(:write_to_file).returns true
   end
 
-  it "Should add a default param to defaults file, without a provider" do
-    defaults_result = @defaults.add_defaults_to_conf({"organization_id"=> 3}, nil)
-    assert_equal 3, defaults_result[:defaults][:organization_id][:value]
+  describe '#add_defaults_to_conf' do
+    it "Should add a default param to defaults file, without a provider" do
+      defaults_result = @defaults.add_defaults_to_conf({"organization_id"=> 3}, nil)
+      assert_equal 3, defaults_result[:defaults][:organization_id][:value]
+    end
+
+    it "Should update dashed default when underscored default is set" do
+      defaults_result = @defaults.add_defaults_to_conf({"location-id"=> 3}, nil)
+      assert_equal 3, defaults_result[:defaults][:'location-id'][:value]
+      assert_equal nil, defaults_result[:defaults][:location_id]
+    end
+
+    context "dashed" do
+      let(:filepath) { File.join(File.dirname(__FILE__), '/fixtures/defaults/defaults_dashed.yml') }
+      it "Should update underscored default when dashed default is set" do
+        defaults_result = @defaults.add_defaults_to_conf({"location_id"=> 3}, nil)
+        assert_equal 3, defaults_result[:defaults][:location_id][:value]
+        assert_equal nil, defaults_result[:defaults][:'location-id']
+      end
+    end
+
+    it "Should add a default param to defaults file, with provider" do
+      defaults_result = @defaults.add_defaults_to_conf({"location_id"=>nil}, :foreman)
+      assert_equal :foreman, defaults_result[:defaults][:location_id][:provider]
+    end
   end
 
-  it "Should add a default param to defaults file, with provider" do
-    defaults_result = @defaults.add_defaults_to_conf({"location_id"=>nil}, :foreman)
-    assert_equal :foreman, defaults_result[:defaults][:location_id][:provider]
+  describe '#delete_default_from_conf' do
+    it "Should remove default param from defaults file" do
+      defaults_result = @defaults.delete_default_from_conf(:organization_id)
+      assert_nil defaults_result[:defaults][:organization_id]
+    end
+
+    it "Should remove dashed default param from defaults file" do
+      defaults_result = @defaults.delete_default_from_conf(:"organization-id")
+      assert_nil defaults_result[:defaults][:organization_id]
+    end
+
+    context "dashed" do
+      let(:filepath) { File.join(File.dirname(__FILE__), '/fixtures/defaults/defaults_dashed.yml') }
+      it "Should remove default param from defaults file" do
+        defaults_result = @defaults.delete_default_from_conf(:organization_id)
+        assert_nil defaults_result[:defaults][:'organization-id']
+      end
+
+      it "Should remove dashed default param from defaults file" do
+        defaults_result = @defaults.delete_default_from_conf(:"organization-id")
+        assert_nil defaults_result[:defaults][:'organization-id']
+      end
+    end
   end
 
-  it "Should remove default param from defaults file" do
-    defaults_result = @defaults.delete_default_from_conf(:organization_id)
-    assert_nil defaults_result[:defaults][:organization_id]
+  describe '#defaults_set' do
+    it "should check if the defaults is set" do
+      assert_equal true, @defaults.defaults_set?("location_id")
+    end
   end
 
-  it "should get the default param, without provider" do
-    assert_equal 2, @defaults.get_defaults("location_id")
-  end
 
-  it "should get the default param, with provider" do
-    fake_provider = mock()
-    fake_provider.stubs(:provider_name).returns(:foreman)
-    fake_provider.expects(:get_defaults).with(:organization_id).returns(3)
-    @defaults.register_provider(fake_provider)
-    assert_equal 3, @defaults.get_defaults("organization_id")
+  describe '#get_defaults' do
+    it "should get the default param, without provider" do
+      assert_equal 2, @defaults.get_defaults("location_id")
+    end
+
+    it "should get the default param, with provider" do
+      fake_provider = mock()
+      fake_provider.stubs(:provider_name).returns(:foreman)
+      fake_provider.expects(:get_defaults).with(:organization_id).returns(3)
+      @defaults.register_provider(fake_provider)
+      assert_equal 3, @defaults.get_defaults("organization_id")
+    end
+
+    context 'dashed params' do
+      let(:filepath) { File.join(File.dirname(__FILE__), '/fixtures/defaults/defaults_dashed.yml') }
+
+      it "should get the default param, without provider" do
+        assert_equal 2, @defaults.get_defaults("location_id")
+      end
+
+      it "should get the default param, with provider" do
+        fake_provider = mock()
+        fake_provider.stubs(:provider_name).returns(:foreman)
+        fake_provider.expects(:get_defaults).with(:organization_id).returns(3)
+        @defaults.register_provider(fake_provider)
+        assert_equal 3, @defaults.get_defaults("organization_id")
+      end
+    end
   end
 
   it "should return empty defaults when the settings file is not present" do
-    defaults = HammerCLI::Defaults.new(nil, FILEPATH)
+    defaults = HammerCLI::Defaults.new(nil, filepath)
     assert_equal({}, defaults.defaults_settings)
   end
 

--- a/test/unit/fixtures/defaults/defaults_dashed.yml
+++ b/test/unit/fixtures/defaults/defaults_dashed.yml
@@ -1,0 +1,6 @@
+---
+:defaults:
+  :organization-id:
+    :provider: 'foreman'
+  :location-id:
+    :value: 2


### PR DESCRIPTION
It seems more intuitive to use the param names in form they appear on
the command-line (organization_id vs. organization-id). This patch is
adding support for names with dashes.

How to test:
- make sure organization_id is not in defaults
  - `hammer defaults list`
- add organization-id
  - `hammer defaults add --param-name organization-id --provider foreman`
- call command requiring organization-id and check it worked
  - `hammer content-view list`
