### PR TITLE
Fixes #14466 - add support for Gemfile.local.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ruby + project files
 Gemfile.lock
 Gemfile.local
+Gemfile.local.rb
 pkg
 
 # Tests

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,7 @@ group :test do
 end
 
 # load local gemfile
-local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local')
-self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|
+  local_gemfile = File.join(File.dirname(__FILE__), file_name)
+  self.instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)
+end

--- a/doc/development_tips.md
+++ b/doc/development_tips.md
@@ -2,7 +2,7 @@ Development Tips
 ----------------
 
 ### Local gem modifications
-If you want to modify the gems setup for development needs, create a file `Gemfile.local` in the root of your hammer-cli checkout. You can override the setup from `Gemfile` there. This file is git-ignored so you can easily keep your custom tuning.
+If you want to modify the gems setup for development needs, create a file `Gemfile.local.rb` in the root of your hammer-cli checkout. You can override the setup from `Gemfile` there. This file is git-ignored so you can easily keep your custom tuning.
 
 Typical usage is for linking plugins from local checkouts:
 ```ruby
@@ -13,7 +13,7 @@ gem 'hammer_cli_foreman', :path => '../hammer-cli-foreman'
 [Pry](https://github.com/pry/pry) is a runtime developer console for ruby.
 It allows debugging when [Pry Debugger](https://github.com/nixme/pry-debugger) is installed alongside.
 
-For basic usage, add following the lines to your `Gemfile.local`:
+For basic usage, add following the lines to your `Gemfile.local.rb`:
 
 ```ruby
 gem 'pry'


### PR DESCRIPTION
The change keeps backward compatibility with `Gemfile.local`