### PR TITLE
Fixes #14598 - Descriptions from Apipie will not contain unescaped HTML.

### DIFF
--- a/lib/hammer_cli/apipie/option_definition.rb
+++ b/lib/hammer_cli/apipie/option_definition.rb
@@ -11,6 +11,9 @@ module HammerCLI::Apipie
         self.referenced_resource = options.delete(:referenced_resource).to_s if options[:referenced_resource]
       end
       super
+      # Apipie currently sends descriptions as escaped HTML once this is changed this should be removed.
+      # See #15198 on Redmine.
+      @description = CGI::unescapeHTML(description)
     end
 
   end

--- a/test/unit/apipie/option_definition_test.rb
+++ b/test/unit/apipie/option_definition_test.rb
@@ -22,5 +22,14 @@ describe HammerCLI::Apipie::OptionDefinition do
     end
 
   end
+
+  let(:opt2) { HammerCLI::Apipie::OptionDefinition.new("--opt2", "OPT2", "&#39;OPT2&#39;", :referenced_resource => @referenced_resource) }
+
+  describe "Option Description should be converted" do
+    it "should be converted" do
+      opt2.description.must_equal "'OPT2'"
+    end
+
+  end
 end
 


### PR DESCRIPTION
Currently Apipie only sends descriptions in escaped HTML. This causes the descriptions to look strange on escaped characters like ', & and others. 