### PR TITLE
refs #7453 - explicitly list man page in gemspec files

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 Hammer cli provides universal extendable CLI interface for ruby apps
 EOF
 
-  s.files            = Dir['{lib,test,bin,doc,man,config,locale}/**/*', 'LICENSE', 'README*', 'hammer_cli_complete']
+  s.files            = Dir['{lib,test,bin,doc,config,locale}/**/*', 'LICENSE', 'README*', 'hammer_cli_complete'] + ['man/hammer.1.gz']
   s.test_files       = Dir['test/**/*']
   s.extra_rdoc_files = Dir['{doc,config}/**/*', 'README*']
   s.require_paths = ["lib"]


### PR DESCRIPTION
Ensures that the man page is built and included in the gem if `gem
build` rather than `rake build` is used.