### PR TITLE
Fixes #16811 - Allow multiple opt validation blocks

### DIFF
--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -11,7 +11,7 @@ module HammerCLI
     include HammerCLI::Subcommand
 
     class << self
-      attr_accessor :validation_block
+      attr_accessor :validation_blocks
     end
 
     def adapter
@@ -39,11 +39,14 @@ module HammerCLI
     end
 
     def self.validate_options(&block)
-      self.validation_block = block
+      self.validation_blocks ||= []
+      self.validation_blocks << block
     end
 
     def validate_options
-      validator.run &self.class.validation_block if self.class.validation_block
+      if self.class.validation_blocks && self.class.validation_blocks.any?
+        self.class.validation_blocks.each { |validation_block| validator.run(&validation_block) }
+      end
     end
 
     def exception_handler

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -376,5 +376,14 @@ describe HammerCLI::AbstractCommand do
     CmdOD2.output_definition.fields.length.must_equal 1
   end
 
+  it "should allow for multiple validation blocks" do
+    class CmdName1 < HammerCLI::AbstractCommand
+      validate_options do; end
+      validate_options do; end
+    end
+
+    assert_equal 2, CmdName1.validation_blocks.length
+  end
+
 end
 


### PR DESCRIPTION
I have a module that defines some option validation and it can be called multiple times. In order to do this, I need to be able to set multiple validation blocks. I tried to write something that could be called from within 'validation_options' but the code there is executed within HammerCLI::Validator so I don't think that'll work.

## Todo
- [x] Add tests