### PR TITLE
Fixes #16822 - Check for nil default values

### DIFF
--- a/lib/hammer_cli/validator.rb
+++ b/lib/hammer_cli/validator.rb
@@ -45,7 +45,10 @@ module HammerCLI
       def get_option_value(name)
         opt = get_option(name)
         value = opt.get
-        value = opt.command.send(:context)[:defaults].get_defaults(name.to_s) if value.nil?
+        if value.nil?
+          defaults = opt.command.send(:context)[:defaults]
+          value = defaults.get_defaults(name.to_s) if defaults
+        end
         value
       end
 


### PR DESCRIPTION
https://github.com/theforeman/hammer-cli/pull/217 introduces failing tests to hammer-cli-foreman and hammer-cli-katello. This nil check fixes both projects.