### PR TITLE
Fixes #17180 - Double quotes in list type params

### DIFF
--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'csv'
 
 module HammerCLI
   module Options
@@ -82,11 +83,11 @@ module HammerCLI
       class List < AbstractNormalizer
 
         def description
-          _("Comma separated list of values.")
+          _("Comma separated list of values. Values containing comma should be double quoted")
         end
 
         def format(val)
-          val.is_a?(String) ? val.split(",") : []
+          val.is_a?(String) ? CSV.parse(val).flatten(1) : []
         end
       end
 

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -79,6 +79,13 @@ module HammerCLI
         end
       end
 
+      CSV_ERROR_MESSAGES = [
+        N_('Missing or stray quote in line %s.'),
+        N_('Unquoted fields do not allow \r or \n (line %s).'),
+        N_('Illegal quoting in line %s.'),
+        N_('Unclosed quoted field on line %s.'),
+        N_('Field size exceeded on line %s.')
+      ]
 
       class List < AbstractNormalizer
 
@@ -87,9 +94,11 @@ module HammerCLI
         end
 
         def format(val)
-          val.is_a?(String) ? CSV.parse(val).flatten(1) : []
+          (val.is_a?(String) && !val.empty?) ? CSV.parse_line(val) : []
         rescue CSV::MalformedCSVError => e
-          raise ArgumentError.new(e.message)
+          match = e.message.match /\d+/
+          message = match ? _(e.message.gsub(/\d+/, '%s')) % match[0] : e.message
+          raise ArgumentError.new(message)
         end
       end
 

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -79,13 +79,13 @@ module HammerCLI
         end
       end
 
-      CSV_ERROR_MESSAGES = [
-        N_('Missing or stray quote in line %s.'),
-        N_('Unquoted fields do not allow \r or \n (line %s).'),
-        N_('Illegal quoting in line %s.'),
-        N_('Unclosed quoted field on line %s.'),
-        N_('Field size exceeded on line %s.')
-      ]
+      CSV_ERROR_MESSAGES = {
+        /Missing or stray quote/ => _('Missing or stray quote.'),
+        /Unquoted fields do not allow/ => _('Unquoted fields do not allow \r or \n.'),
+        /Illegal quoting/ => _('Illegal quoting.'),
+        /Unclosed quoted field/ => _('Unclosed quoted field.'),
+        /Field size exceeded/ => _('Field size exceeded.')
+      }
 
       class List < AbstractNormalizer
 
@@ -96,9 +96,8 @@ module HammerCLI
         def format(val)
           (val.is_a?(String) && !val.empty?) ? CSV.parse_line(val) : []
         rescue CSV::MalformedCSVError => e
-          match = e.message.match /\d+/
-          message = match ? _(e.message.gsub(/\d+/, '%s')) % match[0] : e.message
-          raise ArgumentError.new(message)
+          message = CSV_ERROR_MESSAGES.find { |pattern,| pattern.match e.message } || [e.message]
+          raise ArgumentError.new(message.last)
         end
       end
 

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -88,6 +88,8 @@ module HammerCLI
 
         def format(val)
           val.is_a?(String) ? CSV.parse(val).flatten(1) : []
+        rescue CSV::MalformedCSVError => e
+          raise ArgumentError.new(e.message)
         end
       end
 

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -41,6 +41,10 @@ describe HammerCLI::Options::Normalizers do
     it "should parse a comma separated string containig double quotes" do
       formatter.format('a,b,""c""').must_equal ['a', 'b', '"c"']
     end
+
+    it "should catch quoting errors" do
+      proc { formatter.format('1,"3,4""s') }.must_raise ArgumentError
+    end
   end
 
 

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -33,6 +33,14 @@ describe HammerCLI::Options::Normalizers do
     it "should parse a comma separated string" do
       formatter.format("a,b,c").must_equal ['a', 'b', 'c']
     end
+
+    it "should parse a comma separated string with values including comma" do
+      formatter.format('a,b,"c,d"').must_equal ['a', 'b', 'c,d']
+    end
+
+    it "should parse a comma separated string containig double quotes" do
+      formatter.format('a,b,""c""').must_equal ['a', 'b', '"c"']
+    end
   end
 
 


### PR DESCRIPTION
`--parameter='a,b,"c,d"'` gets parsed as `['a', 'b', 'c,d']`