### PR TITLE
Fixes #17508 - log related error messages to stderr

### DIFF
--- a/lib/hammer_cli/logger.rb
+++ b/lib/hammer_cli/logger.rb
@@ -50,30 +50,33 @@ module HammerCLI
     NOCOLOR_LAYOUT  = Logging::Layouts::Pattern.new(:pattern => pattern, :color_scheme => nil)
     DEFAULT_LOG_DIR = '/var/log/hammer'
 
-    log_dir = File.expand_path(HammerCLI::Settings.get(:log_dir) || DEFAULT_LOG_DIR)
-    begin
-      FileUtils.mkdir_p(log_dir, :mode => 0750)
-    rescue Errno::EACCES => e
-      puts _("No permissions to create log dir %s") % log_dir
+    def self.initialize_logger(logger)
+      log_dir = File.expand_path(HammerCLI::Settings.get(:log_dir) || DEFAULT_LOG_DIR)
+      begin
+        FileUtils.mkdir_p(log_dir, :mode => 0750)
+      rescue Errno::EACCES => e
+        $stderr.puts _("No permissions to create log dir %s") % log_dir
+      end
+
+      filename = "#{log_dir}/hammer.log"
+      begin
+        logger.appenders = ::Logging.appenders.rolling_file('configure',
+                                                            :filename => filename,
+                                                            :layout   => NOCOLOR_LAYOUT,
+                                                            :truncate => false,
+                                                            :keep     => 5,
+                                                            :size     => (HammerCLI::Settings.get(:log_size) || 1)*1024*1024) # 1MB
+        # set owner and group (it's ignored if attribute is nil)
+        FileUtils.chown HammerCLI::Settings.get(:log_owner), HammerCLI::Settings.get(:log_group), filename
+      rescue ArgumentError => e
+        $stderr.puts _("File %s not writeable, won't log anything to the file!") % filename
+      end
+
+      logger.level = HammerCLI::Settings.get(:log_level)
+      logger
     end
 
-    logger   = Logging.logger.root
-    filename = "#{log_dir}/hammer.log"
-    begin
-      logger.appenders = ::Logging.appenders.rolling_file('configure',
-                                                          :filename => filename,
-                                                          :layout   => NOCOLOR_LAYOUT,
-                                                          :truncate => false,
-                                                          :keep     => 5,
-                                                          :size     => (HammerCLI::Settings.get(:log_size) || 1)*1024*1024) # 1MB
-      # set owner and group (it's ignored if attribute is nil)
-      FileUtils.chown HammerCLI::Settings.get(:log_owner), HammerCLI::Settings.get(:log_group), filename
-    rescue ArgumentError => e
-      puts _("File %s not writeable, won't log anything to the file!") % filename
-    end
-
-    logger.level = HammerCLI::Settings.get(:log_level)
-
+    initialize_logger(Logging.logger.root)
   end
 
 end

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -2,6 +2,25 @@ require File.join(File.dirname(__FILE__), 'test_helper')
 require 'tempfile'
 
 describe Logging::LogEvent do
+
+  describe '#initialize_logger' do
+    let (:logger) { Logging::Logger.new(File.open('/dev/null')) }
+
+    it "prints message to stderr when log dir can't be created" do
+        log_dir = "/nonexistant/dir/logs"
+        FileUtils.expects(:mkdir_p).raises(Errno::EACCES)
+
+        HammerCLI::Settings.load({:log_dir => log_dir})
+
+        out, err = capture_io do
+          HammerCLI::Logger::initialize_logger(logger)
+        end
+
+        assert_match "No permissions to create log dir #{log_dir}", err
+        assert_match "File #{log_dir}/hammer.log not writeable, won't log anything to the file!", err
+    end
+  end
+
   context "filtering" do
     before :each do
       @log_output = Logging::Appenders['__test__']


### PR DESCRIPTION
* logger init moved to `initialize_logger`
* error messages are printed to stderr
* test for the error messages