### PR TITLE
Fixes #19033 - Enable SSL verification by default

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -40,6 +40,7 @@ class PreParser < Clamp::Command
   option ["--ssl-client-cert"], "CERT_FILE", "Configure the client's public certificate"
   option ["--ssl-client-key"], "KEY_FILE", "Configure the client's private key"
   option ["--ssl-with-basic-auth"], :flag, "Use standard authentication in addition to client certificate authentication"
+  option ["--fetch-ca-cert"], "SERVER", "Fetch CA certificate from server and exit"
 end
 
 preparser = PreParser.new File.basename($0), {}
@@ -121,6 +122,11 @@ end
 
 # load hammer core
 require 'hammer_cli'
+
+if preparser.fetch_ca_cert
+  require 'hammer_cli/ca_cert_fetcher'
+  exit HammerCLI::CACertFetcher.fetch_ca_cert(preparser.fetch_ca_cert)
+end
 
 # load modules set in config
 begin

--- a/lib/hammer_cli/ca_cert_fetcher.rb
+++ b/lib/hammer_cli/ca_cert_fetcher.rb
@@ -1,0 +1,67 @@
+module HammerCLI
+  class CACertFetcher
+    def self.fetch_ca_cert(host)
+      CACertFetcher.new.fetch_ca_cert(host)
+    end
+
+    def fetch_ca_cert(host)
+      begin
+        uri = URI.parse(host)
+
+        hostname = uri.host
+        port = uri.port || 443
+
+        if hostname.nil?
+          $stderr.puts _("Couldn't parse URI '%s'.") % host
+          $stderr.puts scheme_error(uri)
+          return HammerCLI::EX_SOFTWARE
+        end
+
+        puts get_ca_cert(hostname, port)
+        return HammerCLI::EX_OK
+      rescue StandardError => e
+        msg = [_('Fetching the CA certificate failed:')]
+
+        if e.is_a?(OpenSSL::SSL::SSLError) && e.message.include?('unknown protocol')
+          msg << _('The service at the given URI does not accept SSL connections')
+          msg << scheme_error(uri) if uri.scheme == 'http'
+        else
+          msg << e.message
+        end
+        $stderr.puts msg.join("\n")
+        return HammerCLI::EX_SOFTWARE
+      end
+    end
+
+    protected
+
+    def scheme_error(uri)
+      _("Perhaps you meant to connect to '%s'?") % uri_to_https(uri)
+    end
+
+    def uri_to_https(uri)
+      https_uri = uri.to_s
+      if uri.scheme == 'http'
+        # Scheme is http, replace with https.
+        https_uri = https_uri.sub(/^http/, 'https')
+      elsif uri.scheme.nil? || !https_uri.match(/:\/\//)
+        # Scheme either wasn't recognized or host was parsed into scheme.
+        # That can happen when user enters '<host>:<port>' without scheme.
+        https_uri = "https://#{https_uri}"
+      end
+      https_uri
+    end
+
+    def get_ca_cert(hostname, port)
+      noverify_ssl_connection = OpenSSL::SSL::SSLSocket.new(TCPSocket.new(hostname, port), noverify_ssl_context)
+      noverify_ssl_connection.connect
+      noverify_ssl_connection.peer_cert_chain.last
+    end
+
+    def noverify_ssl_context
+      noverify_ssl_context = OpenSSL::SSL::SSLContext.new
+      noverify_ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      noverify_ssl_context
+    end
+  end
+end

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -23,6 +23,7 @@ module HammerCLI
     option ["--ssl-client-cert"], "CERT_FILE", _("Configure the client's public certificate")
     option ["--ssl-client-key"], "KEY_FILE", _("Configure the client's private key")
     option ["--ssl-with-basic-auth"], :flag, _("Use standard authentication in addition to client certificate authentication")
+    option ["--fetch-ca-cert"], "SERVER", _("Fetch CA certificate from server and exit")
 
     option "--version", :flag, _("show version") do
       puts "hammer (%s)" % HammerCLI.version

--- a/lib/hammer_cli/ssloptions.rb
+++ b/lib/hammer_cli/ssloptions.rb
@@ -13,12 +13,12 @@ module HammerCLI
       ssl_options = {}
       for sslopt in [:ssl_ca_file, :ssl_ca_path, :verify_ssl] do
         ssloptval = read_ssl_option(sslopt)
-        ssl_options[sslopt] = ssloptval if ssloptval
+        ssl_options[sslopt] = ssloptval unless ssloptval.nil?
       end
       ssl_options.merge!(cert_key_options)
 
       # enable ssl verification
-      ssl_options[:verify_ssl] ||= true
+      ssl_options[:verify_ssl] = true if ssl_options[:verify_ssl].nil?
       @logger.debug("SSL options: #{ApipieBindings::Utils::inspect_data(ssl_options)}")
       ssl_options
     end
@@ -26,7 +26,7 @@ module HammerCLI
     protected
 
     def read_ssl_option(key)
-      @settings.get(:_params, key) || @settings.get(:ssl, key)
+      @settings.get(:_params, key).nil? ? @settings.get(:ssl, key) : @settings.get(:_params, key)
     end
 
     def cert_key_options

--- a/lib/hammer_cli/ssloptions.rb
+++ b/lib/hammer_cli/ssloptions.rb
@@ -17,8 +17,8 @@ module HammerCLI
       end
       ssl_options.merge!(cert_key_options)
 
-      # enable ssl verification if verify_ssl is not configured and either CA file or path are present
-      ssl_options[:verify_ssl] = 1 if ssl_options[:verify_ssl].nil? && (ssl_options[:ssl_ca_file] || ssl_options[:ssl_ca_path])
+      # enable ssl verification
+      ssl_options[:verify_ssl] ||= true
       @logger.debug("SSL options: #{ApipieBindings::Utils::inspect_data(ssl_options)}")
       ssl_options
     end

--- a/test/unit/apipie/api_connection_test.rb
+++ b/test/unit/apipie/api_connection_test.rb
@@ -9,6 +9,7 @@ describe HammerCLI::Apipie::ApiConnection do
 
     def api_stub(params = {}, options = {})
       api_stub = stub()
+      options[:verify_ssl] = true if options[:verify_ssl].nil?
       ApipieBindings::API.expects(:new).with(params, options).returns(api_stub)
       api_stub
     end


### PR DESCRIPTION
- enables SSL verification by default
- adds command `hammer --fetch-ca-cert https://foreman.example.com` that prints server CA cert