### PR TITLE
Fixes #19431 - retry command on session expiry

### DIFF
--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -24,11 +24,16 @@ module HammerCLI
     end
 
     def run(arguments)
-      exit_code = super
-      raise "exit code must be integer" unless exit_code.is_a? Integer
+      begin
+        begin
+          exit_code = super
+          raise "exit code must be integer" unless exit_code.is_a? Integer
+        rescue => e
+          exit_code = handle_exception(e)
+        end
+        logger.debug 'Retrying the command' if (exit_code == HammerCLI::EX_RETRY)
+      end while (exit_code == HammerCLI::EX_RETRY)
       return exit_code
-    rescue => e
-      handle_exception e
     end
 
     def parse(arguments)

--- a/lib/hammer_cli/exit_codes.rb
+++ b/lib/hammer_cli/exit_codes.rb
@@ -4,7 +4,7 @@ module HammerCLI
   EX_USAGE        = 64      # command line usage error
   EX_DATAERR      = 65      # data format error
   EX_NOINPUT      = 66      # cannot open input
-  EX_NOUSER       = 67      # addressee unknown 
+  EX_NOUSER       = 67      # addressee unknown
   EX_NOHOST       = 68      # host name unknown
   EX_UNAVAILABLE  = 69      # service unavailable
   EX_SOFTWARE     = 70      # internal software error
@@ -20,4 +20,5 @@ module HammerCLI
   # non POSIX codes
   EX_NOT_FOUND    = 128     # resource was not found
   EX_UNAUTHORIZED = 129     # authorization failed
+  EX_RETRY        = 666     # retry the command
 end


### PR DESCRIPTION
Generic mechanism for retrying commands when they return `EX_RETRY` either from method `execute` or from exception handler.