### PR TITLE
Fixes #11178 - error strings with % in them break messages

### DIFF
--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -8,10 +8,11 @@ class String
         name = name[0]
         params[name.to_s] || params[name.to_sym]
       end
-
-      self.gsub(/%[<]([^>]*)[>]/, '%').gsub(/%[{]([^}]*)[}]/, '%s') % array_params
+      self.gsub(/%[<]([^>]*)[>]/, '%')
+          .gsub(/%[{]([^}]*)[}]/, '%s')
+          .gsub(/\%(\W?[^bBdiouxXeEfgGaAcps])/, '%%\1') % array_params
     else
-      self % params
+      self.gsub(/\%(\W?[^bBdiouxXeEfgGaAcps])/, '%%\1') % params
     end
   end
 

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -15,6 +15,7 @@ describe String do
     let(:str) { "AA%<a>s BB%<b>s" }
     let(:curly_str) { "AA%{a} BB%{b}" }
     let(:pos_str) { "AA%s BB%s" }
+    let(:str_with_percent) { "Error: AA%<a>s BB%<b>s <%# template error %> verify this %>" }
 
     it "should not fail without expected parameters" do
       str.format({}).must_equal 'AA BB'
@@ -34,6 +35,10 @@ describe String do
 
     it "should replace named parameters marked with curly brackets" do
       curly_str.format(:a => 'A', :b => 'B').must_equal 'AAA BBB'
+    end
+
+    it "should not fail due to presence of percent chars in string" do
+      str_with_percent.format({}).must_equal 'Error: AA BB <%# template error %> verify this %>'
     end
 
   end


### PR DESCRIPTION
Except patterns where percent sign with field characters there, I replaced all the remaining `%` signs with `%%` . So that a percent sign itself will be displayed.  
No arguments taken while formatting & will not result into an exception.
[Link](https://apidock.com/ruby/Kernel/sprintf) which I used as a reference.