### PR TITLE
Refs #17135 - Replace CSV parser in List Normalizer

### DIFF
--- a/lib/hammer_cli/csv_parser.rb
+++ b/lib/hammer_cli/csv_parser.rb
@@ -1,0 +1,74 @@
+module HammerCLI
+  class CSVParser
+
+    def initialize
+      reset_parser
+    end
+
+    def parse(data)
+      return [] if data.nil?
+      reset_parser
+      data.split('').each do |char|
+        handle_escape(char) || handle_quoting(char) || handle_comma(char) || add_to_buffer(char)
+      end
+      raise ArgumentError.new(_("Illegal quoting in %{buffer}") % { :buffer => @buffer }) unless @last_quote.nil?
+      clean_buffer
+      @value
+    end
+
+    private
+
+    def handle_comma(char)
+      if char == ','
+        clean_buffer
+        true
+      else
+        false
+      end
+    end
+
+    def handle_quoting(char)
+      if @last_quote.nil? && ["'", '"'].include?(char)
+        @last_quote = char
+        true
+      elsif @last_quote == char
+        @last_quote = nil
+        true
+      elsif @last_quote
+        add_to_buffer(char)
+        true
+      else
+        false
+      end
+    end
+
+    def handle_escape(char)
+      if @escape
+        add_to_buffer(char)
+        @escape = false
+        true
+      elsif char == '\\'
+        @escape = true
+        true
+      else
+        false
+      end
+    end
+
+    def add_to_buffer(char)
+      @buffer += char
+    end
+
+    def reset_parser
+      @value = []
+      @buffer = ''
+      @escape = false
+      @last_quote = nil
+    end
+
+    def clean_buffer
+      @value << @buffer
+      @buffer = ''
+    end
+  end
+end

--- a/lib/hammer_cli/csv_parser.rb
+++ b/lib/hammer_cli/csv_parser.rb
@@ -8,10 +8,10 @@ module HammerCLI
     def parse(data)
       return [] if data.nil?
       reset_parser
-      data.split('').each do |char|
+      data.each_char do |char|
         handle_escape(char) || handle_quoting(char) || handle_comma(char) || add_to_buffer(char)
       end
-      raise ArgumentError.new(_("Illegal quoting in %{buffer}") % { :buffer => @buffer }) unless @last_quote.nil?
+      raise ArgumentError.new(_("Illegal quoting in %{buffer}") % { :buffer => @raw_buffer }) unless @last_quote.nil?
       clean_buffer
       @value
     end
@@ -30,9 +30,11 @@ module HammerCLI
     def handle_quoting(char)
       if @last_quote.nil? && ["'", '"'].include?(char)
         @last_quote = char
+        @raw_buffer += char
         true
       elsif @last_quote == char
         @last_quote = nil
+        @raw_buffer += char
         true
       elsif @last_quote
         add_to_buffer(char)
@@ -49,6 +51,7 @@ module HammerCLI
         true
       elsif char == '\\'
         @escape = true
+        @raw_buffer += char
         true
       else
         false
@@ -57,17 +60,20 @@ module HammerCLI
 
     def add_to_buffer(char)
       @buffer += char
+      @raw_buffer += char
     end
 
     def reset_parser
       @value = []
       @buffer = ''
+      @raw_buffer = ''
       @escape = false
       @last_quote = nil
     end
 
     def clean_buffer
       @value << @buffer
+      @raw_buffer = ''
       @buffer = ''
     end
   end

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'csv'
+require 'hammer_cli/csv_parser'
 
 module HammerCLI
   module Options
@@ -79,25 +79,14 @@ module HammerCLI
         end
       end
 
-      CSV_ERROR_MESSAGES = {
-        /Missing or stray quote/ => _('Missing or stray quote.'),
-        /Unquoted fields do not allow/ => _('Unquoted fields do not allow \r or \n.'),
-        /Illegal quoting/ => _('Illegal quoting.'),
-        /Unclosed quoted field/ => _('Unclosed quoted field.'),
-        /Field size exceeded/ => _('Field size exceeded.')
-      }
 
       class List < AbstractNormalizer
-
         def description
-          _("Comma separated list of values. Values containing comma should be double quoted")
+          _("Comma separated list of values. Values containing comma should be quoted or escaped with backslash")
         end
 
         def format(val)
-          (val.is_a?(String) && !val.empty?) ? CSV.parse_line(val) : []
-        rescue CSV::MalformedCSVError => e
-          message = CSV_ERROR_MESSAGES.find { |pattern,| pattern.match e.message } || [e.message]
-          raise ArgumentError.new(message.last)
+          (val.is_a?(String) && !val.empty?) ? HammerCLI::CSVParser.new.parse(val) : []
         end
       end
 

--- a/test/unit/csv_parser_test.rb
+++ b/test/unit/csv_parser_test.rb
@@ -47,7 +47,8 @@ describe HammerCLI::CSVParser do
     end
 
     it "raises quoting error" do
-      proc { parser.parse('1,"3,4""s') }.must_raise ArgumentError
+      err = proc { parser.parse('1,"3,4""s') }.must_raise ArgumentError
+      err.message.must_equal "Illegal quoting in \"3,4\"\"s"
     end
   end
 end

--- a/test/unit/csv_parser_test.rb
+++ b/test/unit/csv_parser_test.rb
@@ -1,0 +1,53 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+require 'hammer_cli/csv_parser'
+
+describe HammerCLI::CSVParser do
+
+  describe 'parse' do
+    let(:parser) { HammerCLI::CSVParser.new }
+
+    it "parses nil" do
+      parser.parse(nil).must_equal []
+    end
+
+    it "parses empty string" do
+      parser.parse('').must_equal ['']
+    end
+
+    it "parses single value" do
+      parser.parse('a').must_equal ['a']
+    end
+
+    it "parses a dquoted string" do
+      parser.parse('\"a').must_equal ['"a']
+    end
+
+    it "parses a quoted string" do
+      parser.parse("Mary\\'s").must_equal ["Mary's"]
+    end
+
+    it "should parse a comma separated string" do
+      parser.parse("a,b,c").must_equal ['a', 'b', 'c']
+    end
+
+    it "parses a string with escaped comma" do
+      parser.parse('a\,b,c').must_equal ['a,b', 'c']
+    end
+
+    it "should parse a comma separated string with quotes" do
+      parser.parse('a,b,\\"c\\"').must_equal ['a', 'b', '"c"']
+    end
+
+    it "parses a comma separated string with values including comma" do
+      parser.parse('a,b,"c,d"').must_equal ['a', 'b', 'c,d']
+    end
+
+    it "parses a comma separated string with values including comma (dquotes)" do
+      parser.parse("a,b,'c,d'").must_equal ['a', 'b', 'c,d']
+    end
+
+    it "raises quoting error" do
+      proc { parser.parse('1,"3,4""s') }.must_raise ArgumentError
+    end
+  end
+end

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -38,8 +38,12 @@ describe HammerCLI::Options::Normalizers do
       formatter.format('a,b,"c,d"').must_equal ['a', 'b', 'c,d']
     end
 
+    it "should parse a comma separated string with values including comma (doublequotes)" do
+      formatter.format("a,b,'c,d'").must_equal ['a', 'b', 'c,d']
+    end
+
     it "should parse a comma separated string containig double quotes" do
-      formatter.format('a,b,""c""').must_equal ['a', 'b', '"c"']
+      formatter.format('a,b,\"c\"').must_equal ['a', 'b', '"c"']
     end
 
     it "should catch quoting errors" do


### PR DESCRIPTION
The ruby CSV parser causes some usability problems when used to parse list options for more details see [1].
The new parser should be more flexible in syntax and closer to shell quoting conventions. 

[1] https://github.com/theforeman/hammer-cli-foreman/pull/312