### PR TITLE
Fixes #21013 - Number normalizers for Integer params

### DIFF
--- a/lib/hammer_cli/apipie/option_builder.rb
+++ b/lib/hammer_cli/apipie/option_builder.rb
@@ -71,7 +71,7 @@ module HammerCLI::Apipie
       elsif param.validator =~ /Must be one of: (.*)\./
         allowed = $1.split(/,\ ?/).map { |val| val.gsub(/<[^>]*>/i,'') }
         opts[:format] = HammerCLI::Options::Normalizers::Enum.new(allowed)
-      elsif param.expected_type.to_s == 'number' || param.validator =~ /Number/i
+      elsif param.expected_type.to_s == 'numeric' || param.validator =~ /Number/i || param.validator =~ /Integer/i
         opts[:format] = HammerCLI::Options::Normalizers::Number.new
       end
       opts[:attribute_name] = HammerCLI.option_accessor_name(param.name)

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -97,6 +97,12 @@ describe HammerCLI::Apipie::OptionBuilder do
       numeric_option = options.find {|o| o.attribute_name == HammerCLI.option_accessor_name("numeric_param") }
       numeric_option.value_formatter.class.must_equal HammerCLI::Options::Normalizers::Number
     end
+
+    it "should set number normalizer for integer" do
+      integer_option = options.find {|o| o.attribute_name == HammerCLI.option_accessor_name("integer_param") }
+      integer_option.value_formatter.class.must_equal HammerCLI::Options::Normalizers::Number
+    end
+
   end
 
 

--- a/test/unit/fixtures/apipie/documented.json
+++ b/test/unit/fixtures/apipie/documented.json
@@ -162,7 +162,16 @@
                                 "allow_null": false,
                                 "full_name": "documented[numeric_param]",
                                 "validator": "Must be Number",
-                                "expected_type": "number",
+                                "expected_type": "numeric",
+                                "description": "",
+                                "required": false
+                            },
+                            {
+                                "name": "integer_param",
+                                "allow_null": false,
+                                "full_name": "documented[numeric_param]",
+                                "validator": "Integer",
+                                "expected_type": "numeric",
                                 "description": "",
                                 "required": false
                             }


### PR DESCRIPTION
Option builder was updated to recognize params of type Integer.
During investigation of this it was found out that apipie sends
expected_type 'numeric' and not 'number' (since v. 0.0.6). Fixed
that as well.