### PR TITLE
Fixes #21627 - handle 400 bad request - concat response message

### DIFF
--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -17,6 +17,7 @@ module HammerCLI
         [RestClient::ResourceNotFound, :handle_not_found],
         [RestClient::Unauthorized, :handle_unauthorized],
         [RestClient::SSLCertificateNotVerified, :handle_ssl_cert_not_verified],
+        [RestClient::BadRequest, :handle_bad_request],
         [OpenSSL::SSL::SSLError, :handle_ssl_error],
         [ApipieBindings::DocLoadingError, :handle_apipie_docloading_error],
         [ApipieBindings::MissingArgumentsError, :handle_apipie_missing_arguments_error],
@@ -91,6 +92,12 @@ module HammerCLI
       HammerCLI::EX_UNAUTHORIZED
     end
 
+    def handle_bad_request(e)
+      print_error "#{e.message}#{response_message(e.response)}"
+      log_full_error e
+      HammerCLI::EX_BAD_REQUEST
+    end
+
     def rake_command
       "rake apipie:cache"
     end
@@ -148,6 +155,15 @@ module HammerCLI
       print_error e.message
       log_full_error e
       HammerCLI::EX_CONFIG
+    end
+
+    private
+
+    def response_message(response)
+      message = JSON.parse(response.body)["error"]["message"]
+      "\n  #{message}"
+    rescue JSON::ParserError
+      ''
     end
 
   end

--- a/lib/hammer_cli/exit_codes.rb
+++ b/lib/hammer_cli/exit_codes.rb
@@ -20,5 +20,6 @@ module HammerCLI
   # non POSIX codes
   EX_NOT_FOUND    = 128     # resource was not found
   EX_UNAUTHORIZED = 129     # authorization failed
+  EX_BAD_REQUEST  = 665
   EX_RETRY        = 666     # retry the command
 end

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -54,6 +54,19 @@ describe HammerCLI::ExceptionHandler do
     assert_match /Using exception handler HammerCLI::ExceptionHandler#handle_not_found/, @log_output.readline.strip
     assert_match /ERROR  Exception : (Resource )?Not Found/, @log_output.readline.strip
   end
+  it "should handle bad request" do
+    ex = RestClient::BadRequest.new
+    ex.stubs(:response).returns(mock(:body => ''))
+    output.expects(:print_error).with(heading, ex.message)
+    handler.handle_exception(ex, :heading => heading)
+  end
 
+  it "should log bad request error" do
+    ex = RestClient::BadRequest.new
+    ex.stubs(:response).returns(mock(:body => ''))
+    output.default_adapter = :silent
+    handler.handle_exception(ex)
+    assert_match /Using exception handler HammerCLI::ExceptionHandler#handle_bad_request/, @log_output.readline.strip
+    assert_match /ERROR  Exception : Bad Request/, @log_output.readline.strip
+  end
 end
-


### PR DESCRIPTION
This is an attempt to handle all 400 bad request and shows a user-friendly message based on HTTP response.