### PR TITLE
Revert "Fixes #7451 - Review whitespace in extracted strings"

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -118,14 +118,5 @@ puts _("TODO:") +
 ```
 
 
-4) It's recommended to use punctuation at the end of sentences.
-```ruby
-# CORRECT
-puts _("Hello %s") % name
-# RECOMMENDED
-puts _("Hello %s.") % name
-```
-
-
-5) Try setting `:mark_translated: true` to identify gaps in your translations.
+4) Try setting `:mark_translated: true` to identify gaps in your translations.
 This will wrap all translated strings with angle brackets '>message<'.

--- a/lib/hammer_cli/ca_cert_fetcher.rb
+++ b/lib/hammer_cli/ca_cert_fetcher.rb
@@ -4,7 +4,7 @@ module HammerCLI
     def fetch_ca_cert(service_uri, ca_store_path)
       begin
         uri = URI.parse(service_uri)
-        raise URI::InvalidURIError.new(_("Unable to find hostname in %s.") % service_uri) if uri.host.nil?
+        raise URI::InvalidURIError.new(_("Unable to find hostname in #{service_uri}")) if uri.host.nil?
         raise URI::InvalidURIError.new(scheme_error(uri)) unless uri.scheme == 'https'
         ca_cert_manager = HammerCLI::CACertManager.new(ca_store_path)
         raw_cert = HammerCLI::CertDownloader.new.download(uri)
@@ -17,7 +17,7 @@ module HammerCLI
         deb_update_cmd = "update-ca-certificates"
         cert_file = ca_cert_manager.cert_file_name(uri)
 
-        puts _("CA certificate for %{uri} was stored to %{file}.") % {:uri => service_uri, :file => cert_file}
+        puts _("CA certificate for %{uri} was stored to %{file}") % {:uri => service_uri, :file => cert_file}
         puts _("Now hammer can use the downloaded certificate to verify SSL connection to the server.")
         puts _("It will be used automatically when ssl_ca_path and ssl_ca_file options are not set.")
         puts
@@ -52,7 +52,7 @@ module HammerCLI
         $stderr.puts _("To see the actual chain you can use openssl command")
         $stderr.puts "  $ openssl s_client -showcerts -connect #{uri.host}:#{uri.port} </dev/null"
         $stderr.puts
-        $stderr.puts _("You can also download the certificate manually and store it as %s.") % cert_file
+        $stderr.puts _("You can also download the certificate manually and store it as #{cert_file}")
         $stderr.puts _("If you choose any other location set the ssl_ca_path or ssl_ca_file configuration options appropriately.")
         return HammerCLI::EX_SOFTWARE
       rescue StandardError => e
@@ -60,7 +60,7 @@ module HammerCLI
         msg = [_('Fetching the CA certificate failed:')]
 
         if e.is_a?(OpenSSL::SSL::SSLError) && e.message.include?('unknown protocol')
-          msg << _('The service at the given URI does not accept SSL connections.')
+          msg << _('The service at the given URI does not accept SSL connections')
           msg << scheme_error if uri.scheme == 'http'
         else
           msg << e.message

--- a/lib/hammer_cli/clamp.rb
+++ b/lib/hammer_cli/clamp.rb
@@ -2,14 +2,14 @@ require 'clamp'
 
 if Clamp.respond_to?(:messages=)
   Clamp.messages = {
-    :too_many_arguments =>       _("Too many arguments."),
-    :option_required =>          _("Option '%s' is required.") % "%<option>s",
-    :option_or_env_required =>   _("Option '%{opt}' (or env %{env}) is required.") % {:opt => "%<option>s", :env => "%<env>s"},
-    :option_argument_error =>    _("Option '%{swt}': %{msg}.") % {:swt => "%<switch>s", :msg => "%<message>s"},
-    :parameter_argument_error => _("Parameter '%{pmt}': %{msg}.") % {:pmt => "%<param>s", :msg => "%<message>s"},
-    :env_argument_error =>       _("%{env}: %{msg}.") % {:env => "%<env>s", :msg => "%<message>s"},
-    :unrecognised_option =>      _("Unrecognised option '%s'.") % "%<switch>s",
-    :no_such_subcommand =>       _("No such sub-command '%s'.") % "%<name>s",
-    :no_value_provided =>        _("No value provided.")
+    :too_many_arguments =>       _("too many arguments"),
+    :option_required =>          _("option '%<option>s' is required"),
+    :option_or_env_required =>   _("option '%<option>s' (or env %<env>s) is required"),
+    :option_argument_error =>    _("option '%<switch>s': %<message>s"),
+    :parameter_argument_error => _("parameter '%<param>s': %<message>s"),
+    :env_argument_error =>       _("%<env>s: %<message>s"),
+    :unrecognised_option =>      _("Unrecognised option '%<switch>s'"),
+    :no_such_subcommand =>       _("No such sub-command '%<name>s'"),
+    :no_value_provided =>        _("no value provided")
   }
 end

--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -104,5 +104,5 @@ module HammerCLI
 
   end
 
-  HammerCLI::MainCommand.subcommand "defaults", _("Defaults management."), HammerCLI::DefaultsCommand
+  HammerCLI::MainCommand.subcommand "defaults", _("Defaults management"), HammerCLI::DefaultsCommand
 end

--- a/lib/hammer_cli/defaults_commands.rb
+++ b/lib/hammer_cli/defaults_commands.rb
@@ -22,7 +22,7 @@ module HammerCLI
   class DefaultsCommand < HammerCLI::AbstractCommand
     class ProvidersDefaultsCommand < HammerCLI::DefaultsCommand
       command_name 'providers'
-      desc _('List all the providers.')
+      desc _('List all the providers')
 
       def execute
         data = context[:defaults].providers.map do |key, val|
@@ -53,7 +53,7 @@ module HammerCLI
 
     class ListDefaultsCommand < HammerCLI::DefaultsCommand
       command_name 'list'
-      desc _('List all the default parameters.')
+      desc _('List all the default parameters')
 
       def execute
         data = context[:defaults].defaults_settings.map do |key, val|
@@ -83,8 +83,8 @@ module HammerCLI
     class DeleteDefaultsCommand < HammerCLI::DefaultsCommand
       command_name 'delete'
 
-      desc _('Delete a default param.')
-      option "--param-name", "OPTION_NAME", _("The name of the default option."), :required => true
+      desc _('Delete a default param')
+      option "--param-name", "OPTION_NAME", _("The name of the default option"), :required => true
 
       def execute
         if context[:defaults] && context[:defaults].defaults_set?(option_param_name)
@@ -100,9 +100,9 @@ module HammerCLI
     class AddDefaultsCommand < HammerCLI::DefaultsCommand
       command_name 'add'
 
-      desc _('Add a default parameter to config.')
+      desc _('Add a default parameter to config')
       option "--param-name", "OPTION_NAME", _("The name of the default option (e.g. organization_id)."), :required => true
-      option "--param-value", "OPTION_VALUE", _("The value for the default option.")
+      option "--param-value", "OPTION_VALUE", _("The value for the default option")
       option "--provider", "OPTION_PROVIDER", _("The name of the provider providing the value. For list available providers see `hammer defaults providers`.")
 
       def execute

--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -69,7 +69,7 @@ module HammerCLI
 
     def handle_usage_exception(e)
       print_error (_("Error: %{message}") + "\n\n" +
-                   _("See: '%{path} --help'.")) % {:message => e.message, :path => e.command.invocation_path}
+                   _("See: '%{path} --help'")) % {:message => e.message, :path => e.command.invocation_path}
       log_full_error e
       HammerCLI::EX_USAGE
     end
@@ -111,7 +111,7 @@ module HammerCLI
     end
 
     def ssl_cert_message
-      message = _("SSL certificate verification failed.")
+      message = _("SSL certificate verification failed")
       message += "\n#{ssl_cert_instructions}" if ssl_cert_instructions
       message
     end
@@ -138,7 +138,7 @@ module HammerCLI
     end
 
     def handle_apipie_missing_arguments_error(e)
-      message = _("Missing arguments for %s.") % "'#{e.params.join("', '")}'"
+      message = _("Missing arguments for %s") % "'#{e.params.join("', '")}'"
       print_error message
       log_full_error e, message
       HammerCLI::EX_USAGE

--- a/lib/hammer_cli/full_help.rb
+++ b/lib/hammer_cli/full_help.rb
@@ -2,7 +2,7 @@ require 'hammer_cli/abstract'
 
 module HammerCLI
   class FullHelpCommand < HammerCLI::AbstractCommand
-    option "--md", :flag, _("Format output in markdown.")
+    option "--md", :flag, _("Format output in markdown")
 
     def execute
       @adapter = option_md? ? MDAdapter.new : TxtAdapter.new
@@ -80,5 +80,5 @@ module HammerCLI
     end
   end
 
-  HammerCLI::MainCommand.subcommand "full-help", _("Print help for all hammer commands."), HammerCLI::FullHelpCommand
+  HammerCLI::MainCommand.subcommand "full-help", _("Print help for all hammer commands"), HammerCLI::FullHelpCommand
 end

--- a/lib/hammer_cli/logger.rb
+++ b/lib/hammer_cli/logger.rb
@@ -55,7 +55,7 @@ module HammerCLI
       begin
         FileUtils.mkdir_p(log_dir, :mode => 0750)
       rescue Errno::EACCES => e
-        $stderr.puts _("No permissions to create log dir %s.") % log_dir
+        $stderr.puts _("No permissions to create log dir %s") % log_dir
       end
 
       filename = "#{log_dir}/hammer.log"

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -4,51 +4,51 @@ module HammerCLI
 
   class MainCommand < AbstractCommand
 
-    option ["-v", "--verbose"], :flag, _("Be verbose."), :context_target => :verbose
-    option ["-d", "--debug"], :flag, _("Show debugging output."), :context_target => :debug
-    option ["-r", "--reload-cache"], :flag, _("Force reload of Apipie cache.")
+    option ["-v", "--verbose"], :flag, _("be verbose"), :context_target => :verbose
+    option ["-d", "--debug"], :flag, _("show debugging output "), :context_target => :debug
+    option ["-r", "--reload-cache"], :flag, _("force reload of Apipie cache")
 
-    option ["-c", "--config"], "CFG_FILE", _("Path to custom config file.")
+    option ["-c", "--config"], "CFG_FILE", _("path to custom config file")
 
-    option ["-u", "--username"], "USERNAME", _("Username to access the remote system."),
+    option ["-u", "--username"], "USERNAME", _("username to access the remote system"),
       :context_target => :username
-    option ["-p", "--password"], "PASSWORD", _("Password to access the remote system."),
+    option ["-p", "--password"], "PASSWORD", _("password to access the remote system"),
       :context_target => :password
-    option ["-s", "--server"], "SERVER", _("Remote system address."),
+    option ["-s", "--server"], "SERVER", _("remote system address"),
       :context_target => :uri
-    option ["--verify-ssl"], "VERIFY_SSL", _("Configure SSL verification of remote system."),
+    option ["--verify-ssl"], "VERIFY_SSL", _("Configure SSL verification of remote system"),
       :format => HammerCLI::Options::Normalizers::Bool.new
-    option ["--ssl-ca-file"], "CA_FILE", _("Configure the file containing the CA certificates.")
-    option ["--ssl-ca-path"], "CA_PATH", _("Configure the directory containing the CA certificates.")
-    option ["--ssl-client-cert"], "CERT_FILE", _("Configure the client's public certificate.")
-    option ["--ssl-client-key"], "KEY_FILE", _("Configure the client's private key.")
-    option ["--ssl-with-basic-auth"], :flag, _("Use standard authentication in addition to client certificate authentication.")
-    option ["--fetch-ca-cert"], "SERVER", _("Fetch CA certificate from server and exit.")
+    option ["--ssl-ca-file"], "CA_FILE", _("Configure the file containing the CA certificates")
+    option ["--ssl-ca-path"], "CA_PATH", _("Configure the directory containing the CA certificates")
+    option ["--ssl-client-cert"], "CERT_FILE", _("Configure the client's public certificate")
+    option ["--ssl-client-key"], "KEY_FILE", _("Configure the client's private key")
+    option ["--ssl-with-basic-auth"], :flag, _("Use standard authentication in addition to client certificate authentication")
+    option ["--fetch-ca-cert"], "SERVER", _("Fetch CA certificate from server and exit")
 
-    option "--version", :flag, _("Show version.") do
+    option "--version", :flag, _("show version") do
       puts "hammer (%s)" % HammerCLI.version
       HammerCLI::Modules.names.each do |m|
-        module_version = HammerCLI::Modules.find_by_name(m).version rescue _("Unknown version.")
+        module_version = HammerCLI::Modules.find_by_name(m).version rescue _("unknown version")
         puts " * #{m} (#{module_version})"
       end
       exit(HammerCLI::EX_OK)
     end
 
-    option ["--show-ids"], :flag, _("Show ids of associated resources."),
+    option ["--show-ids"], :flag, _("Show ids of associated resources"),
       :context_target => :show_ids
-    option ["--interactive"], "INTERACTIVE", _("Explicitly turn interactive mode on/off."),
+    option ["--interactive"], "INTERACTIVE", _("Explicitly turn interactive mode on/off"),
       :format => HammerCLI::Options::Normalizers::Bool.new,
       :context_target => :interactive
 
-    option ["--csv"], :flag, _("Output as CSV (same as --output=csv).")
-    option ["--output"], "ADAPTER", _("Set output format. One of [%s].") %
+    option ["--csv"], :flag, _("Output as CSV (same as --output=csv)")
+    option ["--output"], "ADAPTER", _("Set output format. One of [%s]") %
       HammerCLI::Output::Output.adapters.keys.join(', '),
       :context_target => :adapter
-    option ["--csv-separator"], "SEPARATOR", _("Character to separate the values."),
+    option ["--csv-separator"], "SEPARATOR", _("Character to separate the values"),
       :context_target => :csv_separator
 
 
-    option "--autocomplete", "LINE", _("Get list of possible endings.") do |line|
+    option "--autocomplete", "LINE", _("Get list of possible endings") do |line|
       # get rid of word 'hammer' on the line
       line = line.to_s.gsub(/^\S+/, '')
 
@@ -64,3 +64,5 @@ module HammerCLI
   end
 
 end
+
+

--- a/lib/hammer_cli/modules.rb
+++ b/lib/hammer_cli/modules.rb
@@ -53,15 +53,15 @@ module HammerCLI
       begin
         require_module(name)
       rescue Exception => e
-        logger.error "Error while loading module #{name}."
-        puts _("Warning: An error occured while loading module %s.") % name
+        logger.error "Error while loading module #{name}"
+        puts _("Warning: An error occured while loading module %s") % name
         # with ModuleLoadingError we assume the error is already logged by the issuer
         logger.error e unless e.is_a?(HammerCLI::ModuleLoadingError)
         raise e
       end
 
       version = find_by_name(name).version
-      logger.info "Extension module #{name} (#{version}) loaded."
+      logger.info "Extension module #{name} (#{version}) loaded"
       true
     end
 
@@ -81,7 +81,7 @@ module HammerCLI
       end
       loaded_for_deps = loaded_modules & disabled_modules
       unless loaded_for_deps.empty?
-        message = _("Error: Some of the required modules are disabled in configuration: %s.") % loaded_for_deps.join(', ')
+        message = _("Error: Some of the required modules are disabled in configuration: %s ") % loaded_for_deps.join(', ')
         raise HammerCLI::ModuleDisabledButRequired.new(message)
       end
     end

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -45,7 +45,7 @@ module HammerCLI
               formatter = JSONInput.new
               formatter.format(val)
             rescue ArgumentError
-              raise ArgumentError, _("Value must be defined as a comma-separated list of key=value or valid JSON.")
+              raise ArgumentError, _("value must be defined as a comma-separated list of key=value or valid JSON")
             end
           end
         end
@@ -86,7 +86,7 @@ module HammerCLI
 
       class List < AbstractNormalizer
         def description
-          _("Comma separated list of values. Values containing comma should be quoted or escaped with backslash.")
+          _("Comma separated list of values. Values containing comma should be quoted or escaped with backslash")
         end
 
         def format(val)
@@ -101,7 +101,7 @@ module HammerCLI
           if numeric?(val)
             val.to_i
           else
-            raise ArgumentError, _("Numeric value is required.")
+            raise ArgumentError, _("numeric value is required")
           end
         end
 
@@ -125,7 +125,7 @@ module HammerCLI
           elsif bool.downcase.match(/^(false|f|no|n|0)$/i)
             return false
           else
-            raise ArgumentError, _("Value must be one of true/false, yes/no, 1/0.")
+            raise ArgumentError, _("value must be one of true/false, yes/no, 1/0")
           end
         end
 
@@ -164,7 +164,7 @@ module HammerCLI
           ::JSON.parse(json_string)
 
         rescue ::JSON::ParserError => e
-          raise ArgumentError, _("Unable to parse JSON input.")
+          raise ArgumentError, _("Unable to parse JSON input")
         end
 
       end
@@ -178,7 +178,7 @@ module HammerCLI
         end
 
         def description
-          _("Possible value(s): %s.") % quoted_values
+          _("Possible value(s): %s") % quoted_values
         end
 
         def format(value)
@@ -186,9 +186,9 @@ module HammerCLI
             value
           else
             if allowed_values.count == 1
-              msg = _("Value must be %s.") % quoted_values
+              msg = _("value must be %s") % quoted_values
             else
-              msg = _("Value must be one of %s.") % quoted_values
+              msg = _("value must be one of %s") % quoted_values
             end
             raise ArgumentError, msg
           end
@@ -209,14 +209,14 @@ module HammerCLI
       class DateTime < AbstractNormalizer
 
         def description
-          _("Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format.")
+          _("Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format")
         end
 
         def format(date)
           raise ArgumentError unless date
           ::DateTime.parse(date).to_s
         rescue ArgumentError
-          raise ArgumentError, _("'%s' is not a valid date.") % date
+          raise ArgumentError, _("'%s' is not a valid date") % date
         end
       end
 
@@ -227,7 +227,7 @@ module HammerCLI
         end
 
         def description
-          _("Any combination (comma separated list) of '%s'.") % quoted_values
+          _("Any combination (comma separated list) of '%s'") % quoted_values
         end
 
         def format(value)
@@ -247,7 +247,7 @@ module HammerCLI
         def parse(arr)
           arr.split(",").uniq.tap do |values|
             unless values.inject(true) { |acc, cur| acc & (@allowed_values.include? cur) }
-              raise ArgumentError, _("Value must be a combination of '%s'.") % quoted_values
+              raise ArgumentError, _("value must be a combination of '%s'") % quoted_values
             end
           end
         end

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -94,15 +94,8 @@ module HammerCLI
         ].compact
 
         str = ""
-        if multivalued?
-          str += _("Can be specified multiple times.")
-          str += " "
-        end
-        unless default_sources.empty?
-          str += _("Default:")
-          str += " "
-          str += default_sources.join(_(", or "))
-        end
+        str += _("Can be specified multiple times. ") if multivalued?
+        str += _("Default: ") + default_sources.join(_(", or ")) unless default_sources.empty?
         str
       end
 

--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -52,7 +52,7 @@ module HammerCLI::Output::Adapter
 
       if collection.meta.pagination_set? && collection.count < collection.meta.subtotal
         pages = (collection.meta.subtotal.to_f/collection.meta.per_page).ceil
-        puts _("Page %{page} of %{total} (use --page and --per-page for navigation).") % {:page => collection.meta.page, :total => pages}
+        puts _("Page %{page} of %{total} (use --page and --per-page for navigation)") % {:page => collection.meta.page, :total => pages}
       end
     end
 

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -36,7 +36,7 @@ module HammerCLI
             path_history << file_path
           end
         rescue Exception => e
-          warn _("Warning: Couldn't load configuration file %{path}: %{message}.") % { path: file_path, message: e.message }
+          warn _("Warning: Couldn't load configuration file %{path}: %{message}") % { path: file_path, message: e.message }
         end
       end
     end

--- a/lib/hammer_cli/shell.rb
+++ b/lib/hammer_cli/shell.rb
@@ -7,7 +7,7 @@ module HammerCLI
 
     class HelpCommand < AbstractCommand
       command_name "help"
-      desc _("Print help for commands.")
+      desc _("Print help for commands")
 
       parameter "[COMMAND] ...", "command"
 
@@ -19,7 +19,7 @@ module HammerCLI
 
     class ExitCommand < AbstractCommand
       command_name "exit"
-      desc _("Exit interactive shell.")
+      desc _("Exit interactive shell")
 
       def execute
         exit HammerCLI::EX_OK
@@ -113,8 +113,8 @@ module HammerCLI
     end
 
     def print_welcome_message
-      print_message(_("Welcome to the hammer interactive shell."))
-      print_message(_("Type 'help' for usage information."))
+      print_message(_("Welcome to the hammer interactive shell"))
+      print_message(_("Type 'help' for usage information"))
     end
 
     def common_prefix(results)
@@ -130,5 +130,5 @@ module HammerCLI
 
   end
 
-  HammerCLI::MainCommand.subcommand "shell", _("Interactive shell."), HammerCLI::ShellCommand
+  HammerCLI::MainCommand.subcommand "shell", _("Interactive shell"), HammerCLI::ShellCommand
 end

--- a/lib/hammer_cli/ssloptions.rb
+++ b/lib/hammer_cli/ssloptions.rb
@@ -55,11 +55,11 @@ module HammerCLI
         options
       elsif options[:ssl_client_cert] || options[:ssl_client_key]
         if options[:ssl_client_cert]
-          warn _("SSL client certificate is set but the key is not.")
+          warn _("SSL client certificate is set but the key is not")
         elsif options[:ssl_client_key]
-          warn _("SSL client key is set but the certificate is not.")
+          warn _("SSL client key is set but the certificate is not")
         end
-        warn _("SSL client authentication disabled.")
+        warn _("SSL client authentication disabled")
         {}
       else
         {}
@@ -69,13 +69,13 @@ module HammerCLI
     def read_certificate(path)
       OpenSSL::X509::Certificate.new(File.read(path)) unless path.nil?
     rescue SystemCallError => e
-      warn _("Could't read SSL client certificate %s.") % path
+      warn _("Could't read SSL client certificate %s") % path
     end
 
     def read_key(path)
       OpenSSL::PKey::RSA.new(File.read(path)) unless path.nil?
     rescue SystemCallError => e
-      warn _("Could't read SSL client key %s.") % path
+      warn _("Could't read SSL client key %s") % path
     end
   end
 end

--- a/lib/hammer_cli/subcommand.rb
+++ b/lib/hammer_cli/subcommand.rb
@@ -91,7 +91,7 @@ module HammerCLI
       def define_subcommand(name, subcommand_class, definition, &block)
         existing = find_subcommand(name)
         if existing
-          raise HammerCLI::CommandConflict, _("Can't replace subcommand %<name>s (%<existing_class>s) with %<name>s (%<new_class>s).") % {
+          raise HammerCLI::CommandConflict, _("can't replace subcommand %<name>s (%<existing_class>s) with %<name>s (%<new_class>s)") % {
             :name => name,
             :existing_class => existing.subcommand_class,
             :new_class => subcommand_class

--- a/lib/hammer_cli/testing/command_assertions.rb
+++ b/lib/hammer_cli/testing/command_assertions.rb
@@ -71,13 +71,13 @@ module HammerCLI
         if heading.nil?
           ["Error: #{message}",
            "",
-           "See: '#{command} --help'.",
+           "See: '#{command} --help'",
            ""].join("\n")
         else
           ["#{heading}:",
            "  Error: #{message}",
            "  ",
-           "  See: '#{command} --help'.",
+           "  See: '#{command} --help'",
            ""].join("\n")
         end
       end

--- a/lib/hammer_cli/validator.rb
+++ b/lib/hammer_cli/validator.rb
@@ -38,7 +38,7 @@ module HammerCLI
 
       def get_option(name)
         name = name.to_s
-        raise _("Unknown option name '%s'.") % name unless @options.has_key? name
+        raise _("Unknown option name '%s'") % name unless @options.has_key? name
         @options[name]
       end
 
@@ -69,8 +69,8 @@ module HammerCLI
 
       def initialize(options, to_check)
         super(options, to_check)
-        @rejected_msg = _("You can't set all options %s at one time.")
-        @required_msg = _("Options %s are required.")
+        @rejected_msg = _("You can't set all options %s at one time")
+        @required_msg = _("Options %s are required")
       end
 
       def exist?
@@ -84,8 +84,8 @@ module HammerCLI
     class OneOptionConstraint < AllConstraint
       def initialize(options, to_check)
         super(options, [to_check])
-        @rejected_msg = _("You can't set option %s.")
-        @required_msg = _("Option %s is required.")
+        @rejected_msg = _("You can't set option %s")
+        @required_msg = _("Option %s is required")
       end
 
       def value
@@ -97,8 +97,8 @@ module HammerCLI
 
       def initialize(options, to_check)
         super(options, to_check)
-        @rejected_msg = _("You can't set any of options %s.")
-        @required_msg = _("At least one of options %s is required.")
+        @rejected_msg = _("You can't set any of options %s")
+        @required_msg = _("At least one of options %s is required")
       end
 
       def exist?
@@ -123,11 +123,11 @@ module HammerCLI
       def required_msg
         case count_present_options
         when 0
-          _("One of options %s is required.")
+          _("One of options %s is required")
         when 1
           ''
         else
-          _("Only one of options %s can be set.")
+          _("Only one of options %s can be set")
         end
       end
 

--- a/test/functional/defaults_test.rb
+++ b/test/functional/defaults_test.rb
@@ -133,7 +133,7 @@ describe 'commands' do
     it 'reports missing parameter name' do
       options = ['--param-value=83']
 
-      expected_result = usage_error_result(cmd, "Option '--param-name' is required.")
+      expected_result = usage_error_result(cmd, "option '--param-name' is required")
 
       result = run_cmd(cmd + options, @context)
       assert_cmd(expected_result, result)

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -36,7 +36,7 @@ describe HammerCLI::ExceptionHandler do
   end
 
   it "should handle usage error" do
-    output.expects(:print_error).with(heading, "Error: wrong_usage\n\nSee: 'command_name --help'.")
+    output.expects(:print_error).with(heading, "Error: wrong_usage\n\nSee: 'command_name --help'")
     handler.handle_exception(Clamp::UsageError.new('wrong_usage', cmd), :heading => heading)
 
   end

--- a/test/unit/modules_test.rb
+++ b/test/unit/modules_test.rb
@@ -85,7 +85,7 @@ describe HammerCLI::Modules do
       it "must log module's name and version" do
         HammerCLI::Modules.expects(:require_module).with("hammer_cli_tom")
         HammerCLI::Modules.load("hammer_cli_tom")
-        @log_output.readline.strip.must_equal "INFO  Modules : Extension module hammer_cli_tom (0.0.1) loaded."
+        @log_output.readline.strip.must_equal "INFO  Modules : Extension module hammer_cli_tom (0.0.1) loaded"
       end
 
       it "must return true when load succeeds" do
@@ -100,7 +100,7 @@ describe HammerCLI::Modules do
     describe "module not found" do
       before :each do
         HammerCLI::Modules.stubs(:require_module).raises(LoadError)
-        @error_msg = "ERROR  Modules : Error while loading module hammer_cli_tom."
+        @error_msg = "ERROR  Modules : Error while loading module hammer_cli_tom"
       end
 
       it "must log an error if the load! fails" do
@@ -127,8 +127,8 @@ describe HammerCLI::Modules do
     describe "module runtime exception" do
       before :each do
         HammerCLI::Modules.stubs(:require_module).raises(RuntimeError)
-        @error_msg = "ERROR  Modules : Error while loading module hammer_cli_tom."
-        @warning_msg = "Warning: An error occured while loading module hammer_cli_tom."
+        @error_msg = "ERROR  Modules : Error while loading module hammer_cli_tom"
+        @warning_msg = "Warning: An error occured while loading module hammer_cli_tom"
       end
 
       it "must log an error if the load! fails" do

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -266,7 +266,7 @@ describe HammerCLI::Options::Normalizers do
     end
 
     it "should list allowed values in description" do
-      formatter.description.must_equal("Possible value(s): 'a', 'b'.")
+      formatter.description.must_equal("Possible value(s): 'a', 'b'")
     end
 
   end
@@ -301,7 +301,7 @@ describe HammerCLI::Options::Normalizers do
     end
 
     it "should list allowed values in description" do
-      formatter.description.must_equal("Any combination (comma separated list) of ''1', '2', 'a', 'b''.")
+      formatter.description.must_equal("Any combination (comma separated list) of ''1', '2', 'a', 'b''")
     end
 
   end

--- a/test/unit/validator_test.rb
+++ b/test/unit/validator_test.rb
@@ -145,7 +145,7 @@ describe "constraints" do
       it "raises exception when the option is present" do
         constraint = cls.new(options, :option_a)
         e = proc{ constraint.rejected }.must_raise HammerCLI::Validator::ValidationError
-        e.message.must_equal "You can't set option --option-a."
+        e.message.must_equal "You can't set option --option-a"
       end
     end
 
@@ -158,7 +158,7 @@ describe "constraints" do
       it "raises exception when the option is present" do
         constraint = cls.new(options, :option_unset_d)
         e = proc{ constraint.required }.must_raise HammerCLI::Validator::ValidationError
-        e.message.must_equal 'Option --option-unset-d is required.'
+        e.message.must_equal 'Option --option-unset-d is required'
       end
     end
 
@@ -257,13 +257,13 @@ describe "constraints" do
       it "raises exception when none of the options is present" do
         constraint = cls.new(options, [:option_unset_d, :option_unset_e])
         e = proc{ constraint.required }.must_raise HammerCLI::Validator::ValidationError
-        e.message.must_equal 'One of options --option-unset-d, --option-unset-e is required.'
+        e.message.must_equal 'One of options --option-unset-d, --option-unset-e is required'
       end
 
       it "raises exception when more than one of the options is present" do
         constraint = cls.new(options, [:option_a, :option_b])
         e = proc{ constraint.required }.must_raise HammerCLI::Validator::ValidationError
-        e.message.must_equal 'Only one of options --option-a, --option-b can be set.'
+        e.message.must_equal 'Only one of options --option-a, --option-b can be set'
       end
     end
   end


### PR DESCRIPTION
Reverts theforeman/hammer-cli#258
I'm reverting this PR as according to the issue description there should not be the "dots" in the descriptions: 
"If I may add this too, it would also be great to review punctuation at the end of strings as this is also very inconsistent. If you type "hammer" with hammer-cli-foreman installed, many of the command descriptions have a trailing "." while others don't. I don't think it should be there."
This change also broke some tests in hammer-cli-foreman and I'd like to have PR fixing it prior the merge.