### PR TITLE
Refs #7451 - tests for message formats

### DIFF
--- a/lib/hammer_cli/testing/messages.rb
+++ b/lib/hammer_cli/testing/messages.rb
@@ -1,0 +1,54 @@
+module HammerCLI
+  module Testing
+    module Messages
+      def get_subcommands(cmd)
+        return [] unless cmd.respond_to? :recognised_subcommands
+        cmd.recognised_subcommands.map { |c| c.subcommand_class }
+      end
+
+      def all_subcommands(cmd, parent=HammerCLI::AbstractCommand)
+        result = []
+        get_subcommands(cmd).each do |klass|
+          if klass < parent
+            result << klass
+            result += all_subcommands(klass, parent)
+          end
+        end
+        result
+      end
+
+      def assert_msg_period(cmd, method_name)
+        if cmd.respond_to?(method_name) && !cmd.send(method_name).nil?
+          assert(cmd.send(method_name).end_with?('.'), "#{cmd}.#{method_name} doesn't end with '.'")
+        end
+      end
+
+      def refute_msg_period(cmd, method_name)
+        if cmd.respond_to?(method_name) && !cmd.send(method_name).nil?
+          refute(cmd.send(method_name).end_with?('.'), "#{cmd}.#{method_name} ends with '.'")
+        end
+      end
+
+      def check_option_description(cmd, opt)
+        refute opt.description.end_with?('.'), "Description for option #{opt.long_switch} in #{cmd} ends with '.'"
+      end
+
+      def check_command_messages(cmd)
+        cmd.recognised_options.each do |opt|
+          check_option_description(cmd, opt)
+        end
+        refute_msg_period(cmd, :desc)
+        assert_msg_period(cmd, :success_message)
+        refute_msg_period(cmd, :failure_message)
+      end
+
+      def check_all_command_messages(main_cmd, parent=HammerCLI::AbstractCommand)
+        all_subcommands(main_cmd, parent).each do |cmd|
+          it "test messages of #{cmd}" do
+            check_command_messages(cmd)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/messages_test.rb
+++ b/test/unit/messages_test.rb
@@ -1,0 +1,7 @@
+require File.join(File.dirname(__FILE__), 'test_helper')
+require 'hammer_cli/testing/messages'
+
+include HammerCLI::Testing::Messages
+describe "message formatting" do
+  check_all_command_messages(HammerCLI::MainCommand)
+end


### PR DESCRIPTION
Tests that check that:
- option descriptions **don't end** with '.'
- command descriptions **don't end** with '.'
- success messages in commands **end** with '.'
- failure messages in commands **don't end** with '.' (because they are glued with ":" and details)
