### PR TITLE
Remove legacy Gemfile code for Ruby < 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
-if RUBY_VERSION < '2.1.0'
-  gem 'clamp', '< 1.1.0'
-  gem 'fast_gettext', '< 1.2.0'
-end
-
 
 group :test do
   gem 'rake', '~> 10.1.0'


### PR DESCRIPTION
@tstrachota Hi! This is for Refactor #21359 (http://projects.theforeman.org/issues/21360). I couldn't find the other file that's linked in that issue.
