### PR TITLE
Refs #7451 - fix  "unknown version" message

### DIFF
--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -28,7 +28,7 @@ module HammerCLI
     option "--version", :flag, _("Show version") do
       puts "hammer (%s)" % HammerCLI.version
       HammerCLI::Modules.names.each do |m|
-        module_version = HammerCLI::Modules.find_by_name(m).version rescue _("Unknown version.")
+        module_version = HammerCLI::Modules.find_by_name(m).version rescue _("unknown version")
         puts " * #{m} (#{module_version})"
       end
       exit(HammerCLI::EX_OK)


### PR DESCRIPTION
Fixes formatting of "unknown version" message that was turned into a
sentence by mistake.

Before this patch:
```
$ hammer --version
hammer (0.12.pre.develop)
 * hammer_cli_foreman (0.12.pre.develop)
 * hammer_cli_foreman_tasks (Unknown version.)
```

With this patch:
```
$ hammer --version
hammer (0.12.pre.develop)
 * hammer_cli_foreman (0.12.pre.develop)
 * hammer_cli_foreman_tasks (unknown version)
```