### PR TITLE
Fixes #21359 - Removes code for ruby < 2.1.0

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -1,13 +1,3 @@
-require 'csv'
-if CSV.const_defined? :Reader
-  # Ruby 1.8 compatible
-  require 'fastercsv'
-  Object.send(:remove_const, :CSV)
-  CSV = FasterCSV
-else
-  # CSV is now FasterCSV in ruby 1.9
-end
-
 require File.join(File.dirname(__FILE__), 'wrapper_formatter')
 
 module HammerCLI::Output::Adapter

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -1,21 +1,5 @@
 
 class String
-
-  # string formatting for ruby 1.8
-  def format(params)
-    if params.is_a? Hash
-      array_params = self.scan(/%[<{]([^>}]*)[>}]/).collect do |name|
-        name = name[0]
-        params[name.to_s] || params[name.to_sym]
-      end
-      self.gsub(/%[<]([^>]*)[>]/, '%')
-          .gsub(/%[{]([^}]*)[}]/, '%s')
-          .gsub(/\%(\W?[^bBdiouxXeEfgGaAcps])/, '%%\1') % array_params
-    else
-      self.gsub(/\%(\W?[^bBdiouxXeEfgGaAcps])/, '%%\1') % params
-    end
-  end
-
   def camelize()
     return self if self !~ /_/ && self =~ /[A-Z]+.*/
     split('_').map{|e| e.capitalize}.join

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -2,13 +2,6 @@ require 'tempfile'
 
 describe HammerCLI::ShellHistory do
 
-  before :each do
-    # Readline::HISOTRY does not implement #clear in Ruby 1.8
-    while not Readline::HISTORY.empty?
-      Readline::HISTORY.pop
-    end
-  end
-
   let :history_file do
     file = Tempfile.new('history')
     file.puts "line 1"

--- a/test/unit/i18n_test.rb
+++ b/test/unit/i18n_test.rb
@@ -40,38 +40,10 @@ describe HammerCLI::I18n do
   let(:domain2) { TestLocaleDomain.new('domain2', true) }
   let(:unavailable_domain) { TestLocaleDomain.new('domain3', false) }
 
-  # skip the tests on older versions of fast_gettext (ruby 2.0)
-  if FastGettext::VERSION >= '1.2.0'
     describe "with fast_gettext >= 1.2.0" do
       it "creates base merge repository" do
         HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Merge
-      end
-
-      it "registers available domains at gettext" do
-        repo = mock
-        FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
-          :path => domain1.locale_dir,
-          :type => domain1.type,
-          :report_warning => false).returns(repo)
-
         HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
-        HammerCLI::I18n.add_domain(domain1)
-      end
-
-      it "skips registering domains that are not available" do
-        HammerCLI::I18n.add_domain(domain1)
-        HammerCLI::I18n.add_domain(domain2)
-        HammerCLI::I18n.add_domain(unavailable_domain)
-        HammerCLI::I18n.domains.must_equal [domain1, domain2]
-      end
-    end
-  end
-
-  describe "with fast_gettext < 1.2.0" do
-    let(:fast_gettext_version) { '1.1.0' }
-
-    it "creates base chain repository" do
-      HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Chain
     end
 
     it "registers available domains at gettext" do
@@ -81,7 +53,6 @@ describe HammerCLI::I18n do
         :type => domain1.type,
         :report_warning => false).returns(repo)
 
-      HammerCLI::I18n.translation_repository.chain.expects(:<<).with(repo)
       HammerCLI::I18n.add_domain(domain1)
     end
 


### PR DESCRIPTION
Hammer no longer supports ruby 2.0, there's no point keeping the old code.