### PR TITLE
Refs #22554 - Pin clamp version to < 1.2.0

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -27,7 +27,7 @@ EOF
   s.require_paths = ["lib"]
   s.executables = ['hammer']
 
-  s.add_dependency 'clamp', '~> 1.0'
+  s.add_dependency 'clamp', '>= 1.0', '< 1.2.0'
   s.add_dependency 'logging'
   s.add_dependency 'unicode-display_width'
   s.add_dependency 'unicode'


### PR DESCRIPTION
There are some tests failing due to updated clamp version.
Temporarily pinning the version to unblock the tests.