### PR TITLE
Fixes #19135 - Possibility to limit fields that are displayed

### DIFF
--- a/doc/commands_modification.md
+++ b/doc/commands_modification.md
@@ -33,10 +33,15 @@ HammerCLIForeman::Host::InfoCommand.extend_output_definition do |definition|
   end
   # Returns output definition of the command or field specified with path.
   # Where:
-  #   path = Array of :key or/and :id or/and 'label']
+  #   path is an Array of field's :key or/and :id or/and 'label'
   definition.at(path)
   # Returns field from current output definition.
   definition.find_field(:id)
+  # Finds and adds fields to a set (creates a new one if the set doesn't exist).
+  # Where:
+  #   sets is an Array of String with set names
+  #   fields is an Array of field's :key or/and :id or/and 'label'
+  definition.update_field_sets(sets, fields)
   # Deletes all fields from current output definition.
   definition.clear
 end
@@ -54,6 +59,12 @@ HammerCLIForeman::Host::InfoCommand.extend_output_definition do |definition|
 HammerCLIForeman::Host::InfoCommand.extend_output_definition do |definition|
                                       definition.at(:path)
                                       .find_field(:id).label = _('New label')
+                                    end
+# Update fields in a field set
+# Adds fields with :field_id and 'My field' to 'SET' set
+HammerCLIForeman::Host::InfoCommand.extend_output_definition do |definition|
+                                      definition.at(:path)
+                                      .update_field_sets('SET', [:field_id, 'My field'])
                                     end
 # Expand a field with new definition
 HammerCLIForeman::Host::InfoCommand.extend_output_definition do |definition|

--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -164,6 +164,14 @@ In cases when you want to deprecate just one of more possible switches use the e
     :deprecated => { '--name' => _('Use --alias instead') }
 ```
 
+#### Predefined options
+Also Hammer offers predefined options now. Those are just options, but with
+predefined functionality. To define them in your command use
+`use_option :option_name` method.
+
+Here is the list of predefined options:
+  * `:fields` Expects a list with fields to show in output, see [example](creating_commands.md#printing-hash-records).
+
 
 ### Option builders
 Hammer commands offer option builders that can be used for automatic option generation.
@@ -523,8 +531,12 @@ Imagine there's an API of some service that returns list of users:
 ```
 
 We can create an output definition that selects and formats some of the fields:
+
+_NOTE_: Every field can be arranged in so-called field sets. All the fields by default go to `'DEFAULT'` and `'ALL'` sets. Fields which are in the `'DEFAULT'` set will be printed by default. To see printed other field sets, use predefined option `--fields NAME`, where `NAME` is a field set name in ALLCAPS.
 ```ruby
 class Command < HammerCLI::AbstractCommand
+  # To be able to select fields which should be printed
+  use_option :fields
 
   output do
     # Simple field with a label. The first parameter is the key in the printed hash.
@@ -536,7 +548,7 @@ class Command < HammerCLI::AbstractCommand
     field :roles, 'System Roles', Fields::List
 
     # Label is used for grouping fields.
-    label 'Contacts' do
+    label 'Contacts', sets: ['ADDITIONAL', 'ALL'] do
       field :email, 'Email'
       field :phone, 'Phone No.'
     end
@@ -565,18 +577,38 @@ Using the base adapter the output will look like:
 ID:            1
 System Roles:  Admin, Editor
 Name:          Tom Sawyer
-Contacts:
-  Email:       tom@email.com
-  Phone No.:   123456111
 Created At:    2012/12/18 15:24:42
 
 ID:            2
 System Roles:  Admin
 Name:          Huckleberry Finn
+Created At:    2012/12/18 15:25:00
+```
+
+Using the base adapter with `--fields ALL` or `--fields DEFAULT,ADDITIONAL` the output will look like:
+```
+ID:            1
+System Roles:  Admin, Editor
+Name:          Tom Sawyer
+Created At:    2012/12/18 15:24:42
+Contacts:
+  Email:       tom@email.com
+  Phone No.:   123456111
+
+ID:            2
+System Roles:  Admin
+Name:          Huckleberry Finn
+Created At:    2012/12/18 15:25:00
 Contacts:
   Email:       huckleberry@email.com
   Phone No.:   123456222
-Created At:    2012/12/18 15:25:00
+```
+
+_NOTE_: `--fields` as well lets you to print desired fields only. E.g. to see the users' emails without any additional information use `--fields contacts/email`:
+```
+Email:       tom@email.com
+
+Email:       huckleberry@email.com
 ```
 
 You can optionally use the output definition from another command as a base and extend it with

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -195,6 +195,7 @@ module HammerCLI
           raise ArgumentError, _('Command extensions should be inherited from %s.') % HammerCLI::CommandExtensions
         end
         extension.delegatee(self)
+        extension.extend_predefined_options(self)
         extension.extend_options(self)
         extension.extend_output(self)
         extension.extend_help(self)

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -9,13 +9,13 @@ require 'hammer_cli/options/validators/dsl_block_validator'
 require 'hammer_cli/clamp'
 require 'hammer_cli/subcommand'
 require 'hammer_cli/options/matcher'
+require 'hammer_cli/options/predefined'
 require 'hammer_cli/help/builder'
 require 'hammer_cli/help/text_builder'
 require 'hammer_cli/command_extensions'
 require 'logging'
 
 module HammerCLI
-
   class AbstractCommand < Clamp::Command
     include HammerCLI::Subcommand
 
@@ -161,12 +161,10 @@ module HammerCLI
       self.class.output_definition
     end
 
-
     def self.output_definition
       @output_definition = @output_definition || inherited_output_definition || HammerCLI::Output::Definition.new
       @output_definition
     end
-
 
     def interactive?
       HammerCLI.interactive?
@@ -202,6 +200,12 @@ module HammerCLI
         extension.extend_help(self)
         logger('Extensions').info "Applied #{extension.details} on #{self}."
         command_extensions << extension
+      end
+    end
+
+    def self.use_option(*names)
+      names.each do |name|
+        HammerCLI::Options::Predefined.use(name, self)
       end
     end
 
@@ -316,7 +320,6 @@ module HammerCLI
       @option_collector ||= HammerCLI::Options::OptionCollector.new(self.class.recognised_options, add_validators(option_sources))
     end
 
-
     def option_sources
       sources = HammerCLI::Options::ProcessorList.new(name: 'DefaultInputs')
       sources << HammerCLI::Options::Sources::CommandLine.new(self)
@@ -348,6 +351,5 @@ module HammerCLI
       end
       od
     end
-
   end
 end

--- a/lib/hammer_cli/command_extensions.rb
+++ b/lib/hammer_cli/command_extensions.rb
@@ -15,7 +15,7 @@ module HammerCLI
     ALLOWED_EXTENSIONS = %i[
       option command_options before_print data output help request
       request_headers headers request_options options request_params params
-      option_sources
+      option_sources predefined_options use_option
     ].freeze
 
     def initialize(options = {})
@@ -54,6 +54,10 @@ module HammerCLI
                     opts: opts, block: block }
     end
 
+    def self.use_option(*names)
+      @predefined_option_names = names
+    end
+
     def self.before_print(&block)
       @before_print_block = block
     end
@@ -89,6 +93,13 @@ module HammerCLI
       return if allowed.empty? || (allowed & @except).any?
 
       self.class.extend_options(command_class)
+    end
+
+    def extend_predefined_options(command_class)
+      allowed = @only & %i[predefined_options use_option]
+      return if allowed.empty? || (allowed & @except).any?
+
+      self.class.extend_predefined_options(command_class)
     end
 
     def extend_before_print(data)
@@ -168,6 +179,11 @@ module HammerCLI
                            &option[:block])
         logger.debug("Added option for #{command_class}: #{option}")
       end
+    end
+
+    def self.extend_predefined_options(command_class)
+      command_class.send(:use_option, *@predefined_option_names)
+      logger.debug("Added predefined options for #{command_class}: #{@predefined_option_names}")
     end
 
     def self.extend_before_print(data)

--- a/lib/hammer_cli/options/predefined.rb
+++ b/lib/hammer_cli/options/predefined.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module HammerCLI
+  module Options
+    # Contains predefined by HammerCLI options for commands
+    module Predefined
+      OPTIONS = {
+        fields: [['--fields'], 'FIELDS', _('Show these fields only'),
+                 format: HammerCLI::Options::Normalizers::List.new,
+                 context_target: :fields]
+      }.freeze
+
+      def self.use(option_name, command_class)
+        unless OPTIONS.key?(option_name)
+          raise ArgumentError, _('There is no such predefined option %s.') % option_name
+        end
+        command_class.send(:option, *OPTIONS[option_name])
+      end
+    end
+  end
+end

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -21,18 +21,12 @@ module HammerCLI::Output::Adapter
 
     protected
 
-    def field_filter
-      filtered = []
-      filtered << Fields::Id unless @context[:show_ids]
-      HammerCLI::Output::FieldFilter.new(filtered)
-    end
-
     def render_fields(fields, data)
-      output = ""
-
-      fields = field_filter.filter(fields)
-      fields = displayable_fields(fields, data)
-
+      output = ''
+      fields = filter_fields(fields).filter_by_classes
+                                    .filter_by_sets
+                                    .filter_by_data(data)
+                                    .filtered_fields
       label_width = label_width(fields)
 
       fields.collect do |field|

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -126,7 +126,7 @@ module HammerCLI::Output::Adapter
       end
     end
 
-    def initialize(context={}, formatters={})
+    def initialize(context = {}, formatters = {}, filters = {})
       super
       @paginate_by_default = false
     end
@@ -148,7 +148,11 @@ module HammerCLI::Output::Adapter
     end
 
     def print_collection(fields, collection)
-      fields = displayable_fields(fields, collection.first, compact_only: true)
+      fields = filter_fields(fields).filter_by_classes
+                                    .filter_by_sets
+                                    .filter_by_data(collection.first,
+                                                    compact_only: true)
+                                    .filtered_fields
       rows = row_data(fields, collection)
       # get headers using columns heuristic
       headers = rows.map{ |r| Cell.headers(r, @context) }.max_by{ |headers| headers.size }
@@ -198,7 +202,7 @@ module HammerCLI::Output::Adapter
     end
 
     def default_headers(fields)
-      fields.select{ |f| !(f.class <= Fields::Id) || @context[:show_ids] }.map { |f| f.label }
+      fields.map(&:label)
     end
 
   end

--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -21,9 +21,11 @@ module HammerCLI::Output::Adapter
     end
 
     def print_collection(all_fields, collection)
-      fields = field_filter.filter(all_fields)
-      fields = displayable_fields(fields, collection.first, compact_only: true)
-
+      fields = filter_fields(all_fields).filter_by_classes
+                                        .filter_by_sets
+                                        .filter_by_data(collection.first,
+                                                        compact_only: true)
+                                        .filtered_fields
       formatted_collection = format_values(fields, collection)
       # calculate hash of column widths (label -> width)
       widths = calculate_widths(fields, formatted_collection)
@@ -63,6 +65,10 @@ module HammerCLI::Output::Adapter
 
     protected
 
+    def classes_filter
+      super << Fields::ContainerField
+    end
+
     def normalize_column(width, value)
       value = value.to_s
       padding = width - HammerCLI::Output::Utils.real_length(value)
@@ -101,12 +107,6 @@ module HammerCLI::Output::Adapter
         return max_width if width >= max_width
       end
       width
-    end
-
-    def field_filter
-      filtered = [Fields::ContainerField]
-      filtered << Fields::Id unless @context[:show_ids]
-      HammerCLI::Output::FieldFilter.new(filtered)
     end
 
     private

--- a/lib/hammer_cli/output/adapter/tree_structure.rb
+++ b/lib/hammer_cli/output/adapter/tree_structure.rb
@@ -1,7 +1,6 @@
 module HammerCLI::Output::Adapter
   class TreeStructure < Abstract
-
-    def initialize(context={}, formatters={})
+    def initialize(context = {}, formatters = {}, filters = {})
       super
       @paginate_by_default = false
     end
@@ -34,15 +33,11 @@ module HammerCLI::Output::Adapter
 
     protected
 
-    def field_filter
-      filtered = []
-      filtered << Fields::Id unless @context[:show_ids]
-      HammerCLI::Output::FieldFilter.new(filtered)
-    end
-
     def render_fields(fields, data)
-      fields = field_filter.filter(fields)
-      fields = displayable_fields(fields, data)
+      fields = filter_fields(fields).filter_by_classes
+                                    .filter_by_sets
+                                    .filter_by_data(data)
+                                    .filtered_fields
       fields.reduce({}) do |hash, field|
         field_data = data_for_field(field, data)
         next unless field.display?(field_data)

--- a/lib/hammer_cli/output/definition.rb
+++ b/lib/hammer_cli/output/definition.rb
@@ -19,6 +19,14 @@ module HammerCLI::Output
       @fields[field_index(field_id)]
     end
 
+    def update_field_sets(set_names, field_ids)
+      set_names = [set_names] unless set_names.is_a?(Array)
+      field_ids = [field_ids] unless field_ids.is_a?(Array)
+      field_ids.each do |field_id|
+        find_field(field_id).sets = find_field(field_id).sets.concat(set_names).uniq
+      end
+    end
+
     def insert(mode, field_id, fields = nil, &block)
       definition = self.class.new
       definition.append(fields, &block)

--- a/lib/hammer_cli/output/field_filter.rb
+++ b/lib/hammer_cli/output/field_filter.rb
@@ -1,21 +1,78 @@
 module HammerCLI::Output
-
   class FieldFilter
+    attr_reader :fields, :filtered_fields
+    attr_accessor :classes_filter, :sets_filter
 
-    def initialize(field_classes=[])
-      @field_classes = field_classes
+    def initialize(fields = [], filters = {})
+      self.fields = fields
+      @classes_filter = filters[:classes_filter] || []
+      @sets_filter = filters[:sets_filter] || []
     end
 
-    def filter(fields)
-      fields = fields.clone
-      @field_classes.each do |cls|
-        fields.reject! do |f|
+    def fields=(fields)
+      @fields = fields || []
+      @filtered_fields = @fields.dup
+    end
+
+    def filter_by_classes(classes = nil)
+      classes ||= @classes_filter
+      classes.each do |cls|
+        @filtered_fields.reject! do |f|
           f.is_a? cls
         end
       end
-      fields
+      self
     end
 
-  end
+    def filter_by_sets(sets = nil)
+      sets ||= @sets_filter
+      return self if sets.empty?
+      set_names, labels = resolve_set_names(sets)
+      @filtered_fields.select! do |f|
+        next true if include_by_label?(labels, f.full_label.downcase)
+        (f.sets & set_names).any?
+      end
+      self
+    end
 
+    def filter_by_data(data, compact_only: false)
+      @filtered_fields = displayable_fields(@filtered_fields,
+                                            data,
+                                            compact_only: compact_only)
+      self
+    end
+
+    private
+
+    def displayable_fields(fields, record, compact_only: false)
+      fields.select do |field|
+        field_data = HammerCLI::Output::Adapter::Abstract.data_for_field(
+          field, record
+        )
+        if compact_only && !field_data.is_a?(HammerCLI::Output::DataMissing)
+          true
+        else
+          field.display?(field_data)
+        end
+      end
+    end
+
+    def include_by_label?(labels, label)
+      return true if labels.include?(label)
+      labels.each do |l|
+        return true if l.start_with?("#{label}/") || label.start_with?(l)
+      end
+      false
+    end
+
+    def resolve_set_names(sets)
+      set_names = []
+      labels = []
+      sets.each do |name|
+        next set_names << name if name.upcase == name
+        labels << name.downcase
+      end
+      [set_names, labels]
+    end
+  end
 end

--- a/lib/hammer_cli/output/output.rb
+++ b/lib/hammer_cli/output/output.rb
@@ -25,6 +25,7 @@ module HammerCLI::Output
 
     def print_record(definition, record)
       adapter.print_record(definition.fields, record) if appropriate_verbosity?(:record)
+      adapter.reset_context
     end
 
     def print_collection(definition, collection)
@@ -32,6 +33,7 @@ module HammerCLI::Output
         collection = HammerCLI::Output::RecordCollection.new([collection].flatten(1))
       end
       adapter.print_collection(definition.fields, collection) if appropriate_verbosity?(:collection)
+      adapter.reset_context
     end
 
     def adapter

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -270,6 +270,7 @@ describe HammerCLI::AbstractCommand do
       option "--test", "TEST", "Test option"
       option "--test-format", "TEST_FORMAT", "Test option with a formatter",
         :format => HammerCLI::Options::Normalizers::List.new
+      use_option :fields
     end
 
     it "should create instances of hammer options" do
@@ -282,6 +283,10 @@ describe HammerCLI::AbstractCommand do
       opt.value_formatter.kind_of?(HammerCLI::Options::Normalizers::List).must_equal true
     end
 
+    it 'should allow using of predefined options' do
+      opt = TestOptionCmd.find_option('--fields')
+      opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
+    end
   end
 
   describe "#options" do

--- a/test/unit/output/field_filter_test.rb
+++ b/test/unit/output/field_filter_test.rb
@@ -1,27 +1,62 @@
 require File.join(File.dirname(__FILE__), '../test_helper')
 
 describe HammerCLI::Output::FieldFilter do
-
-  let(:fields) { [
-    Fields::Field.new(:label => "field"),
-    Fields::Collection.new(:label => "collection"),
-    Fields::Id.new(:label => "id")
-  ] }
+  let(:fields) do
+    [
+      Fields::Field.new(:label => 'field', :hide_blank => true),
+      Fields::Collection.new(:label => 'collection'),
+      Fields::Id.new(:label => 'id', :sets => ['THIN'])
+    ]
+  end
+  let(:container_fields) do
+    fields + [
+      Fields::ContainerField.new(:label => 'container') do
+        field :first, 'first'
+        field :second, 'second', Fields::ContainerField do
+          field :nested, 'nested'
+        end
+      end
+    ]
+  end
   let(:field_labels) { fields.map(&:label).sort }
 
-  it "lets all fields go by default" do
-    f = HammerCLI::Output::FieldFilter.new
-    f.filter(fields).map(&:label).sort.must_equal ["field", "collection", "id"].sort
+  it 'lets all fields go by default' do
+    f = HammerCLI::Output::FieldFilter.new(fields)
+    f.filtered_fields.map(&:label).sort.must_equal ['field', 'collection', 'id'].sort
   end
 
-  it "filters fields by class" do
-    f = HammerCLI::Output::FieldFilter.new([Fields::Id])
-    f.filter(fields).map(&:label).sort.must_equal ["field", "collection"].sort
+  it 'filters fields by class' do
+    f = HammerCLI::Output::FieldFilter.new(fields, classes_filter: [Fields::Id])
+    f.filter_by_classes.filtered_fields.map(&:label).sort.must_equal ['field', 'collection'].sort
   end
 
-  it "filters fields by superclass" do
-    f = HammerCLI::Output::FieldFilter.new([Fields::ContainerField])
-    f.filter(fields).map(&:label).sort.must_equal ["field", "id"].sort
+  it 'filters fields by superclass' do
+    f = HammerCLI::Output::FieldFilter.new(fields, classes_filter: [Fields::ContainerField])
+    f.filter_by_classes.filtered_fields.map(&:label).sort.must_equal ['field', 'id'].sort
   end
 
+  it 'filters fields by sets' do
+    f = HammerCLI::Output::FieldFilter.new(fields, sets_filter: ['THIN'])
+    f.filter_by_sets.filtered_fields.map(&:label).must_equal ['id']
+  end
+
+  it 'filters fields by sets with labels' do
+    f = HammerCLI::Output::FieldFilter.new(fields, sets_filter: ['THIN', 'field'])
+    f.filter_by_sets.filtered_fields.map(&:label).sort.must_equal ['field', 'id'].sort
+  end
+
+  it 'filters by full labels' do
+    f = HammerCLI::Output::FieldFilter.new(container_fields, sets_filter: ['container/first'])
+    f.filter_by_sets.filtered_fields.map(&:label).must_equal ['container']
+  end
+
+  it 'allows chained filtering' do
+    f = HammerCLI::Output::FieldFilter.new(fields, sets_filter: ['THIN'], classes_filter: [Fields::Id])
+    f.filter_by_classes.filter_by_sets.filtered_fields.map(&:label).must_equal []
+  end
+
+  it 'filters fields by data' do
+    f = HammerCLI::Output::FieldFilter.new(fields)
+    f.filter_by_data(nil).filtered_fields.map(&:label).sort.must_equal ['id', 'collection'].sort
+  end
 end


### PR DESCRIPTION
Requires #275 to be merged first. PR already goes with that commit for testing.

The [issue](http://projects.theforeman.org/issues/19135) suggests --columns option while I suggest --only, because it works with all the adapters (not for table nor list commands only) and it's shorter :)

Also it accepts labels, which user sees, as arguments, so as mentioned in the issue e.g.:
`hammer subnet list --columns name,vlanid` will not work, while
`hammer --only name,"vlan id" subnet list` will work.