### PR TITLE
Fixes #21633 - Allow modification of additional help texts

### DIFF
--- a/doc/developer_docs.md
+++ b/doc/developer_docs.md
@@ -8,6 +8,7 @@ before creating hammer specific plugins.
 Contents:
  - [Writing a plugin](writing_a_plugin.md#writing-your-own-hammer-plugin)
  - [Creating commands](creating_commands.md#create-your-first-command)
+ - [Help modification](help_modification.md#modify-an-existing-help)
  - [Option builders](option_builders.md#option-builders)
  - [Creating ApiPie commands](creating_apipie_commands.md#creating-commands-for-restful-api-with-apipie)
  - [Development tips](development_tips.md#development-tips)

--- a/doc/help_modification.md
+++ b/doc/help_modification.md
@@ -1,0 +1,119 @@
+Modify an existing help
+-------------------------
+Each command might have its own help definition. This definition is composed of various _help items_, which might contain their own definitions.
+
+Let's say `hammer host create -h` help string has the following structure:
+```
+hammer host create -h
++-- Usage
++-- Options
++-- Additional info
+|   +-- Section(Available keys for --interface:)
+|   |  +-- List
+|   |  +-- Section
+|   |  |  +-- List
+|   |  +-- Section
+|   |  |  +-- List
+|   |  +-- Section
+|   |  |  +-- List
+|   +-- Section(Provider specific options:)
+|   |  +-- Section
+|   |  |  +-- Section
+|   |  |  |  +-- List
+...
+|   |  +-- Section(Libvirt:)
+|   |  |  +-- Section(--compute-attributes:)
+|   |  |  |  +-- List[
+                   cpus                Number of CPUs
+                   memory              String, amount of memory, value in bytes
+                   start               Boolean (expressed as 0 or 1), whether to start the machine or not
+                 ]
+...
+|   |  |  +-- Section
+|   |  |  |  +-- List
+```
+Every `Section`, `List` and simple `Text` is _help item_ defined as `HammerCLI::Help::AbstractItem`, so everything might have its own ID now for easier addressing.
+
+To modify the structure above, you might use the following:
+```ruby
+HammerCLIForeman::Host::CreateCommand.extend_help do |h|
+  # Simple addition to the end.
+  h.section
+  h.list
+  h.text
+
+  # Inserts one or more help items.
+  # Where:
+  #   :mode is one of [:before, :after, :replace]
+  #   :item_id is item's id or label. Item's label can be used if it does not
+  # have an id, e.g. any Section
+  #   block is block of code with new items
+  h.insert(:mode, :item_id) do |h|
+    h.section
+    h.list
+    h.text
+  end
+  # Addition to custom path.
+  # Where:
+  #   path is Array of :item_id or/and 'item_label'
+  #   block is the code block with new help items.
+  h.at(path) do |h|
+    ...
+    h.section
+    h.list
+    h.text
+    ...
+  end
+  # Returns help item from current definition.
+  h.find_item(:item_id)
+end
+```
+
+#### Examples
+```ruby
+# Add a new section with list to the end of the Libvirt section.
+HammerCLIForeman::Host::CreateCommand.extend_help do |h|
+  h.at(['Provider specific options', 'Libvirt']) do |h|
+    h.section('--new-section-with-list', id: :section_with_list) do |h|
+      h.list([
+        ['item1', _('Desc1')],
+        ['item2'],
+        ['item3', _('Desc3')]
+      ], id: :list_with_id)
+    end
+  end
+end
+
+# Add important information
+HammerCLIForeman::Host::CreateCommand.extend_help do |h|
+  h.at(['Provider specific options']) do |h|
+    h.insert(:before, 'EC2') do |h|
+      h.text('Something important for all providers')
+    end
+    h.at(['EC2']) do |h|
+      h.insert(:before, '--compute-attributes') do |h|
+        h.text('Something important for EC2 only')
+      end
+    end
+  end
+end
+
+# Delete the Libvirt section from Provider specific options section.
+HammerCLIForeman::Host::CreateCommand.extend_help do |h|
+  h.at('Provider specific options') do |h|
+    h.insert(:replace, 'Libvirt') do |h|; end
+  end
+end
+
+# Add more text
+HammerCLIForeman::Host::CreateCommand.extend_help do |h|
+  h.at('Provider specific options') do |h|
+    h.insert(:before, 'EC2') do |h|
+      h.text('Imagine it already was here', id: :old_text_id)
+    end
+  end
+  h.at(['Provider specific options', :old_text_id]) do |h|
+    h.text('Additional information', id: :additional_text)
+  end
+end
+```

--- a/lib/hammer_cli/help/definition.rb
+++ b/lib/hammer_cli/help/definition.rb
@@ -1,0 +1,60 @@
+require_relative 'definition/abstract_item'
+require_relative 'definition/text'
+require_relative 'definition/list'
+require_relative 'definition/section'
+
+module HammerCLI
+  module Help
+    class Definition < Array
+      def build_string
+        @out = StringIO.new
+        each do |item|
+          next unless item.is_a? AbstractItem
+          @out.puts unless first_print?
+          @out.puts item.build_string
+        end
+        @out.string
+      end
+
+      def find_item(item_id)
+        self[item_index(item_id)]
+      end
+
+      def at(path)
+        return super(path) if path.is_a? Integer
+        return self if path.empty?
+        expand_path(path)
+      end
+
+      def insert_definition(mode, item_id, definition)
+        index = item_index(item_id)
+        index += 1 if mode == :after
+        delete_at(index) if mode == :replace
+        definition.each_with_index do |item, offset|
+          insert(index + offset, item)
+        end
+      end
+
+      private
+
+      def expand_path(path)
+        path = [path] unless path.is_a? Array
+        item = find_item(path[0])
+        return item if path[1..-1].empty?
+        item.definition.at(path[1..-1])
+      end
+
+      def first_print?
+        @out.size.zero?
+      end
+
+      def item_index(item_id)
+        index = find_index do |item|
+          item.id == item_id
+        end
+        raise ArgumentError, "Help item '#{item_id}' not found" if index.nil?
+        index
+      end
+    end
+  end
+end

--- a/lib/hammer_cli/help/definition/abstract_item.rb
+++ b/lib/hammer_cli/help/definition/abstract_item.rb
@@ -1,0 +1,38 @@
+module HammerCLI
+  module Help
+    class AbstractItem
+      INDENT_STEP = 2
+
+      attr_reader :id
+      attr_accessor :definition
+
+      def initialize(options = {})
+        @id = options[:id]
+        @indentation = options[:indentation]
+      end
+
+      def build_string
+        raise NotImplementedError
+      end
+
+      def self.indent(content, indentation = nil)
+        indentation ||= ' ' * INDENT_STEP
+        content = content.split("\n") unless content.is_a? Array
+        content.map do |line|
+          (indentation + line).rstrip
+        end.join("\n")
+      end
+
+      protected
+
+      def build_definition(content)
+        raise NotImplementedError
+      end
+
+      def indent(content, indentation = nil)
+        indentation ||= @indentation
+        self.class.indent(content, indentation)
+      end
+    end
+  end
+end

--- a/lib/hammer_cli/help/definition/list.rb
+++ b/lib/hammer_cli/help/definition/list.rb
@@ -1,0 +1,53 @@
+module HammerCLI
+  module Help
+    class List < AbstractItem
+      LIST_INDENT = 20
+
+      def initialize(items, options = {})
+        super(options)
+        @indent_size = options[:indent_size] || indent_size(items)
+        build_definition(items || [])
+      end
+
+      def build_string
+        out = StringIO.new
+        @definition.each do |item|
+          out.puts item.build_string
+        end
+        out.string
+      end
+
+      protected
+
+      def build_definition(items)
+        @definition = Definition.new
+        items.each do |item|
+          @definition << Text.new(format_item(item))
+        end
+        @definition
+      end
+
+      private
+
+      def indent_size(items)
+        items = normalize(items)
+        max_len = items.map { |i| i[0].to_s.length }.max
+        (max_len + INDENT_STEP > LIST_INDENT) ? (max_len + INDENT_STEP) : LIST_INDENT
+      end
+
+      def format_item(item)
+        col1, col2 = item
+        col2 = indent(col2.to_s, ' ' * @indent_size).lstrip
+        line = "%-#{@indent_size}s%s" % [col1, col2]
+        line.strip!
+        line
+      end
+
+      def normalize(items)
+        items.map do |i|
+          i.is_a?(Array) ? i : [i]
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli/help/definition/section.rb
+++ b/lib/hammer_cli/help/definition/section.rb
@@ -1,0 +1,36 @@
+module HammerCLI
+  module Help
+    class Section < AbstractItem
+      attr_reader :label
+
+      def initialize(label, definition = nil, options = {})
+        super(options)
+        @label = label
+        @richtext = options[:richtext] || false
+        @id ||= label
+        build_definition(definition)
+      end
+
+      def build_string
+        out = StringIO.new
+        out.puts heading
+        out.puts indent(@definition.build_string)
+        out.string
+      end
+
+      protected
+
+      def build_definition(content)
+        @definition = content || Definition.new
+      end
+
+      private
+
+      def heading
+        label = "#{@label}:"
+        label = HighLine.color(label, :bold) if @richtext
+        label
+      end
+    end
+  end
+end

--- a/lib/hammer_cli/help/definition/text.rb
+++ b/lib/hammer_cli/help/definition/text.rb
@@ -1,0 +1,21 @@
+module HammerCLI
+  module Help
+    class Text < AbstractItem
+      def initialize(text = nil, options = {})
+        super(options)
+        build_definition(text)
+      end
+
+      def build_string
+        @text
+      end
+
+      protected
+
+      def build_definition(content)
+        @text = content || ''
+        @definition = Definition.new([self])
+      end
+    end
+  end
+end

--- a/test/unit/help/definition/abstract_item_test.rb
+++ b/test/unit/help/definition/abstract_item_test.rb
@@ -1,0 +1,33 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLI::Help::AbstractItem do
+  describe '#indent' do
+    let(:first_item) { HammerCLI::Help::Text.new('Lorem ipsum') }
+    let(:second_item) { HammerCLI::Help::Text.new(' Dolor sit amet') }
+    let(:sub_definition) { HammerCLI::Help::Definition.new([first_item, second_item]) }
+
+    it 'indents text' do
+      section = HammerCLI::Help::Section.new('Heading', sub_definition)
+      expected_result = [
+        'Heading:',
+        '  Lorem ipsum',
+        '',
+        '   Dolor sit amet',
+        ''
+      ].join("\n")
+      section.build_string.must_equal(expected_result)
+    end
+
+    it 'indents text with custom padding' do
+      section = HammerCLI::Help::Section.new('Heading', sub_definition, indentation: '**')
+      expected_result = [
+        'Heading:',
+        '**Lorem ipsum',
+        '**',
+        '** Dolor sit amet',
+        ''
+      ].join("\n")
+      section.build_string.must_equal(expected_result)
+    end
+  end
+end

--- a/test/unit/help/definition/list_test.rb
+++ b/test/unit/help/definition/list_test.rb
@@ -1,0 +1,17 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLI::Help::List do
+  describe '#build_string' do
+    let(:first_item)  { [:first,   'This is first line'] }
+    let(:second_item) { [:second,  'This is second line'] }
+    let(:list) { HammerCLI::Help::List.new([first_item, second_item]) }
+
+    it 'builds string' do
+      list.build_string.must_equal [
+        'first               This is first line',
+        'second              This is second line',
+        ''
+      ].join("\n")
+    end
+  end
+end

--- a/test/unit/help/definition/section_test.rb
+++ b/test/unit/help/definition/section_test.rb
@@ -1,0 +1,25 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLI::Help::Section do
+  describe '#build_string' do
+    let(:section)     { HammerCLI::Help::Section.new('section') }
+    let(:first_text)  { HammerCLI::Help::Text.new('first') }
+    let(:second_text) { HammerCLI::Help::Text.new('second') }
+
+    it 'builds string without definition' do
+      section.build_string.must_equal "section:\n\n"
+    end
+
+    it 'builds string with definition' do
+      section.definition = HammerCLI::Help::Definition.new([first_text, second_text])
+      expected_output =  [
+        'section:',
+        '  first',
+        '',
+        '  second',
+        ''
+      ].join("\n")
+      section.build_string.must_equal expected_output
+    end
+  end
+end

--- a/test/unit/help/definition/text_test.rb
+++ b/test/unit/help/definition/text_test.rb
@@ -1,0 +1,11 @@
+require File.join(File.dirname(__FILE__), '../../test_helper')
+
+describe HammerCLI::Help::Text do
+  describe '#build_string' do
+    let(:text) { HammerCLI::Help::Text.new('text') }
+
+    it 'builds string' do
+      text.build_string.must_equal 'text'
+    end
+  end
+end

--- a/test/unit/help/definition_test.rb
+++ b/test/unit/help/definition_test.rb
@@ -1,0 +1,236 @@
+require File.join(File.dirname(__FILE__), '../test_helper')
+
+describe HammerCLI::Help::Definition do
+  let(:definition) { HammerCLI::Help::Definition.new }
+  let(:old_text_item)  { HammerCLI::Help::Text.new('Lorem ipsum', id: :old) }
+  let(:new_text_item)  { HammerCLI::Help::Text.new('Dolor sit amet', id: :new) }
+
+  describe '#build_string' do
+    describe 'text' do
+      it 'prints text via definition' do
+        definition << HammerCLI::Help::Text.new('Lorem ipsum')
+        definition.build_string.must_equal "Lorem ipsum\n"
+      end
+
+      it 'prints multiple blocks with spaces via definition' do
+        definition << HammerCLI::Help::Text.new('Lorem ipsum')
+        definition << HammerCLI::Help::Text.new('Dolor sit amet')
+        definition.build_string.must_equal [
+          'Lorem ipsum',
+          '',
+          'Dolor sit amet',
+          ''
+        ].join("\n")
+      end
+    end
+
+    describe 'section' do
+      it 'prints section heading via definition' do
+        definition << HammerCLI::Help::Section.new('Heading')
+        definition.build_string.must_equal "Heading:\n\n"
+      end
+
+      it 'indents section content via definition' do
+        sub_definition = HammerCLI::Help::Definition.new
+        sub_definition << HammerCLI::Help::Text.new('Lorem ipsum')
+        sub_definition << HammerCLI::Help::Text.new('Dolor sit amet')
+        definition << HammerCLI::Help::Section.new('Heading', sub_definition)
+        definition.build_string.must_equal [
+          'Heading:',
+          '  Lorem ipsum',
+          '',
+          '  Dolor sit amet',
+          ''
+        ].join("\n")
+      end
+    end
+
+    describe 'list' do
+      it 'prints empty list via definition' do
+        builder = HammerCLI::Help::TextBuilder.new
+        builder.list([])
+        builder.definition.build_string.must_equal ''
+      end
+
+      it 'prints single column list' do
+        definition << HammerCLI::Help::List.new([
+          :a,
+          :bb,
+          :ccc
+        ])
+        definition.build_string.must_equal [
+          'a',
+          'bb',
+          'ccc',
+          ''
+        ].join("\n")
+      end
+
+      it 'prints two column list via definition' do
+        definition << HammerCLI::Help::List.new([
+          [:a,   'This is line A'],
+          [:bb,  'This is line B'],
+          [:ccc]
+        ])
+        definition.build_string.must_equal [
+          'a                   This is line A',
+          'bb                  This is line B',
+          'ccc',
+          ''
+        ].join("\n")
+      end
+
+      it 'handles multiple lines in the second column via definition' do
+        definition << HammerCLI::Help::List.new([
+          [:a,   "This is line A\nThis is line A part two"],
+          [:bb,  'This is line B'],
+          [:ccc, 'This is line C']
+        ])
+        definition.build_string.must_equal [
+          'a                   This is line A',
+          '                    This is line A part two',
+          'bb                  This is line B',
+          'ccc                 This is line C',
+          ''
+        ].join("\n")
+      end
+
+      it 'can adjust indentation of the second column via definition' do
+        definition << HammerCLI::Help::List.new([
+          ['a',  'This is line A'],
+          ['This line B is too long for the first column',   'This is line B'],
+          ['ccc', 'This is line C']
+        ])
+        definition.build_string.must_equal [
+          'a                                             This is line A',
+          'This line B is too long for the first column  This is line B',
+          'ccc                                           This is line C',
+          ''
+        ].join("\n")
+      end
+    end
+  end
+
+  describe '#find_item' do
+    it 'finds an item' do
+      definition << old_text_item
+      definition << new_text_item
+      definition.find_item(:new).must_equal new_text_item
+    end
+  end
+
+  describe '#insert_definition' do
+    let(:new_definition) { HammerCLI::Help::Definition.new([new_text_item, new_text_item]) }
+    let(:section_item)   { HammerCLI::Help::Section.new('section', id: :section) }
+
+    describe 'before' do
+      it 'should insert new help item before the old one' do
+        definition << old_text_item
+        definition.insert_definition(:before, :old, new_text_item.definition)
+        definition.first.id.must_equal new_text_item.id
+        definition.count.must_equal 2
+      end
+
+      it 'should insert multiple items before old item' do
+        definition << old_text_item
+        definition.insert_definition(:before, :old, new_definition)
+        definition.first.id.must_equal new_text_item.id
+        definition.count.must_equal 3
+      end
+
+      it 'should work with labels' do
+        definition << section_item
+        definition.insert_definition(:before, 'section', new_definition)
+        definition.first.id.must_equal new_text_item.id
+        definition.count.must_equal 3
+      end
+    end
+
+    describe 'after' do
+      it 'should insert new help item after the old one' do
+        definition << old_text_item
+        definition.insert_definition(:after, :old, new_text_item.definition)
+        definition[0].id.must_equal old_text_item.id
+        definition[1].id.must_equal new_text_item.id
+        definition.count.must_equal 2
+      end
+
+      it 'should insert multiple items after old item' do
+        definition << old_text_item
+        definition.insert_definition(:after, :old, new_definition)
+        definition[0].id.must_equal old_text_item.id
+        definition[1].id.must_equal new_text_item.id
+        definition[2].id.must_equal new_text_item.id
+        definition.count.must_equal 3
+      end
+
+      it 'should work with labels' do
+        definition << section_item
+        definition.insert_definition(:after, 'section', new_text_item.definition)
+        definition[1].id.must_equal new_text_item.id
+        definition.count.must_equal 2
+      end
+    end
+
+    describe 'replace' do
+      it 'should replace the old help item with new one' do
+        definition << old_text_item
+        definition.insert_definition(:replace, :old, new_text_item.definition)
+        definition.first.id.must_equal new_text_item.id
+        definition.count.must_equal 1
+      end
+
+      it 'should replace the old help item with new ones' do
+        definition << old_text_item
+        definition.insert_definition(:replace, :old, new_definition)
+        definition[0].id.must_equal new_text_item.id
+        definition[1].id.must_equal new_text_item.id
+        definition.count.must_equal 2
+      end
+
+      it 'should work with labels' do
+        definition << section_item
+        definition.insert_definition(:replace, 'section', new_text_item.definition)
+        definition.first.id.must_equal new_text_item.id
+        definition.count.must_equal 1
+      end
+    end
+  end
+
+  describe '#at' do
+    it 'should return self if path is empty' do
+      definition << old_text_item
+      definition.at([]) do |h|
+        h.definition.first.id.must_equal old_text_item.id
+      end
+    end
+
+    it 'should accept integer' do
+      definition << old_text_item
+      definition << new_text_item
+      definition.at(1) do |h|
+        h.definition.first.id.must_equal new_text_item.id
+      end
+    end
+
+    it 'should return definition of specified help item with path' do
+      sub_definition = HammerCLI::Help::Definition.new
+      sub_definition << old_text_item
+      sub_definition << new_text_item
+      definition << HammerCLI::Help::Section.new('first', sub_definition, id: :first_section)
+      definition << HammerCLI::Help::Section.new('second', sub_definition, id: :second_section)
+      definition.at(:first_section).definition << HammerCLI::Help::Section.new('nested', sub_definition, id: :nested_section)
+      definition.at([:first_section, :nested_section]).definition.first.id.must_equal old_text_item.id
+    end
+
+    it 'should work with labels' do
+      sub_definition = HammerCLI::Help::Definition.new
+      sub_definition << old_text_item
+      sub_definition << new_text_item
+      definition << HammerCLI::Help::Section.new('first', sub_definition)
+      definition << HammerCLI::Help::Section.new('second', sub_definition)
+      definition.at('first').definition << HammerCLI::Help::Section.new('nested', sub_definition)
+      definition.at(['first', 'nested']).definition.first.id.must_equal old_text_item.id
+    end
+  end
+end


### PR DESCRIPTION
Currently the help string builds on the fly to actual string, so it is not so easy to change it externally. I suggest to build a sort of skeleton or some structure with definitions as it is with command's `output_definition` at first and build the help string at the end of all of the extensions/modifications.

Even though help now builds via `help.definition.build_string`, I left everything in `help/text_builder` for backwards compatibility, which leads to some code duplications in `help/definition`.

Here the [docs](https://github.com/ofedoren/hammer-cli/blob/feat-21633-modif-help-text/doc/help_modification.md).