### PR TITLE
Fixes #17010 - Hammer JSON output uses inconsistent capitalization

### DIFF
--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -10,6 +10,9 @@
   #:mark_translated: false
   # Hide headers from output of list actions
   # :no_headers: true
+  # Choose capitalization for JSON/YAML output.
+  # One of: 'downcase', 'capitalize', 'upcase'
+  # :capitalization: 'downcase'
 
 # Enable/disable color output of logger in Clamp commands
 :watch_plain: false

--- a/lib/hammer_cli/context.rb
+++ b/lib/hammer_cli/context.rb
@@ -1,16 +1,13 @@
 require 'hammer_cli/defaults'
 
 module HammerCLI
-
   def self.context
     @context ||= {
       :defaults => HammerCLI.defaults,
       :is_tty? => HammerCLI.tty?,
       :api_connection => HammerCLI::Connection.new(Logging.logger['Connection']),
-      :no_headers => HammerCLI::Settings.get(:ui, :no_headers)
+      :no_headers => HammerCLI::Settings.get(:ui, :no_headers),
+      :capitalization => HammerCLI.capitalization
     }
   end
-
 end
-
-

--- a/lib/hammer_cli/output/adapter/json.rb
+++ b/lib/hammer_cli/output/adapter/json.rb
@@ -12,15 +12,7 @@ module HammerCLI::Output::Adapter
     end
 
     def print_message(msg, msg_params={})
-      id = msg_params["id"] || msg_params[:id]
-      name = msg_params["name"] || msg_params[:name]
-
-      data = {
-        :message => msg.format(msg_params)
-      }
-      data[:id] = id unless id.nil?
-      data[:name] = name unless name.nil?
-
+      data = prepare_message(msg, msg_params)
       puts JSON.pretty_generate(data)
     end
 

--- a/lib/hammer_cli/output/adapter/yaml.rb
+++ b/lib/hammer_cli/output/adapter/yaml.rb
@@ -12,15 +12,7 @@ module HammerCLI::Output::Adapter
     end
 
     def print_message(msg, msg_params={})
-      id = msg_params["id"] || msg_params[:id]
-      name = msg_params["name"] || msg_params[:name]
-
-      data = {
-        :message => msg.format(msg_params)
-      }
-      data[:id] = id unless id.nil?
-      data[:name] = name unless name.nil?
-
+      data = prepare_message(msg, msg_params)
       puts YAML.dump(data)
     end
 

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -42,6 +42,18 @@ class String
 
 end
 
+class Hash
+  # for ruby < 2.5.0
+  def transform_keys
+    result = {}
+    each do |key, value|
+      new_key = yield key
+      result[new_key] = value
+    end
+    result
+  end
+end
+
 module HammerCLI
 
   def self.tty?
@@ -62,4 +74,12 @@ module HammerCLI
     path
   end
 
+  def self.capitalization
+    supported = %w[downcase capitalize upcase]
+    capitalization = HammerCLI::Settings.get(:ui, :capitalization).to_s
+    return nil if capitalization.empty?
+    return capitalization if supported.include?(capitalization)
+    warn _("Cannot use such capitalization. Try one of %s.") % supported.join(', ')
+    nil
+  end
 end

--- a/test/unit/output/adapter/json_test.rb
+++ b/test/unit/output/adapter/json_test.rb
@@ -245,6 +245,65 @@ describe HammerCLI::Output::Adapter::Json do
       proc { adapter.print_collection(fields, data) }.must_output(expected_output)
     end
 
+    context 'capitalization' do
+      let(:fields)   { [name, surname] }
+      let(:raw_hash) { { 'Name' => 'John', 'Surname' => 'Doe' } }
+      let(:settings) { HammerCLI::Settings }
+      let(:context) { { :capitalization => HammerCLI.capitalization } }
+
+      it 'should respect selected downcase capitalization' do
+        settings.load({ :ui => { :capitalization => :downcase } })
+        hash = [raw_hash.transform_keys(&:downcase)]
+        expected_output = JSON.pretty_generate(hash) + "\n"
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should respect selected capitalize capitalization' do
+        settings.load({ :ui => { :capitalization => :capitalize } })
+        hash = [raw_hash.transform_keys(&:capitalize)]
+        expected_output = JSON.pretty_generate(hash) + "\n"
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should respect selected upcase capitalization' do
+        settings.load({ :ui => { :capitalization => :upcase } })
+        hash = [raw_hash.transform_keys(&:upcase)]
+        expected_output = JSON.pretty_generate(hash) + "\n"
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should print a warn for not supported capitalization' do
+        settings.load({ :ui => { :capitalization => :unsupported } })
+        hash = [raw_hash]
+        expected_error = "Cannot use such capitalization. Try one of downcase, capitalize, upcase.\n"
+        expected_output = JSON.pretty_generate(hash) + "\n"
+        out, err = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+        err.must_equal(expected_error)
+      end
+
+      it "shouldn't change capitalization if wasn't selected" do
+        settings.load({ :ui => { :capitalization => nil } })
+        hash = [raw_hash]
+        expected_output = JSON.pretty_generate(hash) + "\n"
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+    end
+
     context "show ids" do
 
       let(:context) { {:show_ids => true} }

--- a/test/unit/output/adapter/yaml_test.rb
+++ b/test/unit/output/adapter/yaml_test.rb
@@ -242,6 +242,65 @@ describe HammerCLI::Output::Adapter::Yaml do
       proc { adapter.print_collection(fields, data) }.must_output(expected_output)
     end
 
+    context 'capitalization' do
+      let(:fields)   { [name, surname] }
+      let(:raw_hash) { { 'Name' => 'John', 'Surname' => 'Doe' } }
+      let(:settings) { HammerCLI::Settings }
+      let(:context) { { :capitalization => HammerCLI.capitalization } }
+
+      it 'should respect selected downcase capitalization' do
+        settings.load({ :ui => { :capitalization => :downcase } })
+        hash = [raw_hash.transform_keys(&:downcase)]
+        expected_output = YAML.dump(hash)
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should respect selected capitalize capitalization' do
+        settings.load({ :ui => { :capitalization => :capitalize } })
+        hash = [raw_hash.transform_keys(&:capitalize)]
+        expected_output = YAML.dump(hash)
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should respect selected upcase capitalization' do
+        settings.load({ :ui => { :capitalization => :upcase } })
+        hash = [raw_hash.transform_keys(&:upcase)]
+        expected_output = YAML.dump(hash)
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'should print a warn for not supported capitalization' do
+        settings.load({ :ui => { :capitalization => :unsupported } })
+        hash = [raw_hash]
+        expected_error = "Cannot use such capitalization. Try one of downcase, capitalize, upcase.\n"
+        expected_output = YAML.dump(hash)
+        out, err = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+        err.must_equal(expected_error)
+      end
+
+      it "shouldn't change capitalization if wasn't selected" do
+        settings.load({ :ui => { :capitalization => nil } })
+        hash = [raw_hash]
+        expected_output = YAML.dump(hash)
+        out, = capture_io do
+          adapter.print_collection(fields, data)
+        end
+        out.must_equal(expected_output)
+      end
+    end
+
     context "show ids" do
 
       let(:context) { {:show_ids => true} }

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -110,7 +110,16 @@ describe String do
 
 end
 
-
+describe Hash do
+  context 'transform_keys' do
+    let(:hash) { { :one => 'one', :two => 'two', 'three' => 3 } }
+    let(:transformed_hash) { { :ONE => 'one', :TWO => 'two', 'THREE' => 3 } }
+    it 'should return a new hash with new keys' do
+      new_hash = hash.transform_keys(&:upcase)
+      new_hash.must_equal transformed_hash
+    end
+  end
+end
 
 describe HammerCLI do
 
@@ -170,4 +179,3 @@ describe HammerCLI do
   end
 
 end
-


### PR DESCRIPTION
Since there are people which prefer different capitalization types, I suggest to let the user to specify which one they want in `cli_config.yml`.

This fix also fixes capitalization of YAML output.