### PR TITLE
Bump clamp dep to >=1.1

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -27,7 +27,7 @@ EOF
   s.require_paths = ["lib"]
   s.executables = ['hammer']
 
-  s.add_dependency 'clamp', '>= 1.0', '< 1.2.0'
+  s.add_dependency 'clamp', '>= 1.1', '< 1.2.0'
   s.add_dependency 'logging'
   s.add_dependency 'unicode-display_width'
   s.add_dependency 'unicode'


### PR DESCRIPTION
Fixes #24908

declare_subcommand_parameter does not exist before clamp
1.1.0