### PR TITLE
Fixes #19191 - Output formatter applies for selected adapter only

### DIFF
--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -3,7 +3,7 @@ module HammerCLI::Output::Adapter
   class Abstract
 
     def tags
-      []
+      [:abstract]
     end
 
     def initialize(context={}, formatters={})

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -5,7 +5,7 @@ module HammerCLI::Output::Adapter
     LABEL_DIVIDER = ": "
 
     def tags
-      [:flat, :screen]
+      [:base, :flat, :screen]
     end
 
     def print_record(fields, record)

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -132,7 +132,7 @@ module HammerCLI::Output::Adapter
     end
 
     def tags
-      [:flat]
+      [:csv, :flat]
     end
 
     def row_data(fields, collection)

--- a/lib/hammer_cli/output/adapter/json.rb
+++ b/lib/hammer_cli/output/adapter/json.rb
@@ -1,5 +1,8 @@
 module HammerCLI::Output::Adapter
   class Json < TreeStructure
+    def tags
+      [:json]
+    end
 
     def print_record(fields, record)
       result = prepare_collection(fields, [record].flatten(1))

--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -13,7 +13,7 @@ module HammerCLI::Output::Adapter
     COLUMN_SEPARATOR = ' | '
 
     def tags
-      [:screen, :flat]
+      [:table, :screen, :flat]
     end
 
     def print_record(fields, record)

--- a/lib/hammer_cli/output/adapter/tree_structure.rb
+++ b/lib/hammer_cli/output/adapter/tree_structure.rb
@@ -7,9 +7,7 @@ module HammerCLI::Output::Adapter
     end
 
     def tags
-      [
-        :data
-      ]
+      [:tree_structure, :data]
     end
 
     def prepare_collection(fields, collection)

--- a/lib/hammer_cli/output/adapter/yaml.rb
+++ b/lib/hammer_cli/output/adapter/yaml.rb
@@ -1,5 +1,8 @@
 module HammerCLI::Output::Adapter
   class Yaml < TreeStructure
+    def tags
+      [:yaml]
+    end
 
     def print_record(fields, record)
       result = prepare_collection(fields, [record].flatten(1))

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -123,4 +123,26 @@ describe HammerCLI::Output::Adapter::Abstract do
       assert_equal adapter.send(:data_for_field, field, record), :value1
     end
   end
+
+  context 'formatters' do
+    it 'should apply formatter if tags were matched' do
+      adapter_class.any_instance.stubs(:tags).returns([:abstract, :unknown])
+      formatter = UnknownTestFormatter.new
+      formatter.match?(adapter_class.new.tags).must_equal true
+    end
+
+    it 'should apply formatter for selected adapter' do
+      adapter_class.any_instance.stubs(:tags).returns([:abstract, :unknown])
+      formatter = UnknownTestFormatter.new
+      formatter.stubs(:tags).returns([:abstract, :unknown])
+      formatter.match?(adapter_class.new.tags).must_equal true
+    end
+
+    it 'should not apply formatter for others, but selected adapter only' do
+      adapter_class.any_instance.stubs(:tags).returns([:abstract, :unknown])
+      formatter = UnknownTestFormatter.new
+      formatter.stubs(:tags).returns([:table, :unknown])
+      formatter.match?(adapter_class.new.tags).must_equal false
+    end
+  end
 end


### PR DESCRIPTION
Now it is possible to apply an output formatter on selected adapters only.

To use this feature, define `applicable_adapters` **OR** `not_applicable_adapters` method in your formatter like this:

```ruby
class MyFormatter < HammerCLI::Output::Formatters::FieldFormatter
  def applicable_adapters
    [HammerCLI::Output::Adapter::Table]
  end

  def tags
    # tags
  end
  
  def format(data, field_params = {})
    # logic
  end
end
```

Similar to apply on all the adapters except a particular one:

```ruby
class MyFormatter < HammerCLI::Output::Formatters::FieldFormatter
  def not_applicable_adapters
    [HammerCLI::Output::Adapter::Table]
  end

  def tags
    # tags
  end
  
  def format(data, field_params = {})
    # logic
  end
end
```

**NOTE:** If none of the methods defined, everything has default behaviour.