### PR TITLE
Fixes #21359 - Hammer no longer supports ruby < 2.0

### DIFF
--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -1,13 +1,4 @@
 require 'csv'
-if CSV.const_defined? :Reader
-  # Ruby 1.8 compatible
-  require 'fastercsv'
-  Object.send(:remove_const, :CSV)
-  CSV = FasterCSV
-else
-  # CSV is now FasterCSV in ruby 1.9
-end
-
 require File.join(File.dirname(__FILE__), 'wrapper_formatter')
 
 module HammerCLI::Output::Adapter

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -1,7 +1,5 @@
 
 class String
-
-  # string formatting for ruby 1.8
   def format(params)
     if params.is_a? Hash
       array_params = self.scan(/%[<{]([^>}]*)[>}]/).collect do |name|

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -1,12 +1,8 @@
 require 'tempfile'
 
 describe HammerCLI::ShellHistory do
-
   before :each do
-    # Readline::HISOTRY does not implement #clear in Ruby 1.8
-    while not Readline::HISTORY.empty?
-      Readline::HISTORY.pop
-    end
+    Readline::HISTORY.clear
   end
 
   let :history_file do
@@ -68,4 +64,3 @@ describe HammerCLI::ShellHistory do
   end
 
 end
-

--- a/test/unit/i18n_test.rb
+++ b/test/unit/i18n_test.rb
@@ -40,52 +40,23 @@ describe HammerCLI::I18n do
   let(:domain2) { TestLocaleDomain.new('domain2', true) }
   let(:unavailable_domain) { TestLocaleDomain.new('domain3', false) }
 
-  # skip the tests on older versions of fast_gettext (ruby 2.0)
-  if FastGettext::VERSION >= '1.2.0'
-    describe "with fast_gettext >= 1.2.0" do
-      it "creates base merge repository" do
-        HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Merge
-      end
-
-      it "registers available domains at gettext" do
-        repo = mock
-        FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
-          :path => domain1.locale_dir,
-          :type => domain1.type,
-          :report_warning => false).returns(repo)
-
-        HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
-        HammerCLI::I18n.add_domain(domain1)
-      end
-
-      it "skips registering domains that are not available" do
-        HammerCLI::I18n.add_domain(domain1)
-        HammerCLI::I18n.add_domain(domain2)
-        HammerCLI::I18n.add_domain(unavailable_domain)
-        HammerCLI::I18n.domains.must_equal [domain1, domain2]
-      end
-    end
-  end
-
-  describe "with fast_gettext < 1.2.0" do
-    let(:fast_gettext_version) { '1.1.0' }
-
-    it "creates base chain repository" do
-      HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Chain
+  describe 'with fast_gettext >= 1.2.0' do
+    it 'creates base merge repository' do
+      HammerCLI::I18n.translation_repository.class.must_equal FastGettext::TranslationRepository::Merge
     end
 
-    it "registers available domains at gettext" do
+    it 'registers available domains at gettext' do
       repo = mock
       FastGettext::TranslationRepository.expects(:build).with(domain1.domain_name,
         :path => domain1.locale_dir,
         :type => domain1.type,
         :report_warning => false).returns(repo)
 
-      HammerCLI::I18n.translation_repository.chain.expects(:<<).with(repo)
+      HammerCLI::I18n.translation_repository.expects(:add_repo).with(repo)
       HammerCLI::I18n.add_domain(domain1)
     end
 
-    it "skips registering domains that are not available" do
+    it 'skips registering domains that are not available' do
       HammerCLI::I18n.add_domain(domain1)
       HammerCLI::I18n.add_domain(domain2)
       HammerCLI::I18n.add_domain(unavailable_domain)
@@ -93,4 +64,3 @@ describe HammerCLI::I18n do
     end
   end
 end
-

--- a/test/unit/utils_test.rb
+++ b/test/unit/utils_test.rb
@@ -9,40 +9,31 @@ module Constant
 end
 
 describe String do
+  context 'formatting' do
+    let(:str) { 'AA%<a>s BB%<b>s' }
+    let(:curly_str) { 'AA%{a} BB%{b}' }
+    let(:pos_str) { 'AA%s BB%s' }
+    let(:str_with_percent) { 'Error: AA%<a>s BB%<b>s <%# template error %> verify this %>' }
 
-  context "formatting" do
-
-    let(:str) { "AA%<a>s BB%<b>s" }
-    let(:curly_str) { "AA%{a} BB%{b}" }
-    let(:pos_str) { "AA%s BB%s" }
-    let(:str_with_percent) { "Error: AA%<a>s BB%<b>s <%# template error %> verify this %>" }
-
-    it "should not fail without expected parameters" do
+    it 'should not fail without expected parameters' do
       str.format({}).must_equal 'AA BB'
     end
-
-    it "should replace positional parameters" do
+    it 'should replace positional parameters' do
       pos_str.format(['A', 'B']).must_equal 'AAA BBB'
     end
-
-    it "should replace named parameters" do
+    it 'should replace named parameters' do
       str.format(:a => 'A', :b => 'B').must_equal 'AAA BBB'
     end
-
-    it "should replace named parameters with string keys" do
+    it 'should replace named parameters with string keys' do
       str.format('a' => 'A', 'b' => 'B').must_equal 'AAA BBB'
     end
-
-    it "should replace named parameters marked with curly brackets" do
+    it 'should replace named parameters marked with curly brackets' do
       curly_str.format(:a => 'A', :b => 'B').must_equal 'AAA BBB'
     end
-
-    it "should not fail due to presence of percent chars in string" do
+    it 'should not fail due to presence of percent chars in string' do
       str_with_percent.format({}).must_equal 'Error: AA BB <%# template error %> verify this %>'
     end
-
   end
-
 
   context "camelize" do
 


### PR DESCRIPTION
Cherry-picked from https://github.com/theforeman/hammer-cli/pull/269 and added some changes.