### PR TITLE
Fixes #6935 - Use the tty for the interactive output

### DIFF
--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -1,3 +1,4 @@
+require 'highline'
 
 class String
 
@@ -61,7 +62,6 @@ module HammerCLI
   end
 
   def self.interactive?
-    return false unless tty?
     return HammerCLI::Settings.get(:_params, :interactive) unless HammerCLI::Settings.get(:_params, :interactive).nil?
     HammerCLI::Settings.get(:ui, :interactive) != false
   end
@@ -81,5 +81,9 @@ module HammerCLI
     return capitalization if supported.include?(capitalization)
     warn _("Cannot use such capitalization. Try one of %s.") % supported.join(', ')
     nil
+  end
+
+  def self.interactive_output
+    @interactive_output ||= HighLine.new($stdin, IO.new(IO.sysopen('/dev/tty', 'w'), 'w'))
   end
 end


### PR DESCRIPTION
Removed `return false unless tty?` because of a case when we need to ask for password interactively regardless of STDOUT redirection.

`Hammer.interactive_output` should be used when there is a need to print something regardless of STDOUT redirection.