### PR TITLE
Fixes #25307 - Add ability to disable defaults

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -84,7 +84,6 @@ HammerCLI::Settings.load({
     :interactive => preparser.interactive,
     :debug => preparser.debug?,
     :no_headers => preparser.no_headers?,
-    :use_defaults => preparser.use_defaults?,
     :reload_cache => preparser.reload_cache?,
     :verify_ssl => preparser.verify_ssl,
     :ssl_ca_file => preparser.ssl_ca_file,

--- a/bin/hammer
+++ b/bin/hammer
@@ -13,6 +13,7 @@ require 'hammer_cli/options/normalizers'
 # Option descriptions are never displayed and thus do not require translation.
 class PreParser < Clamp::Command
   option ['-v', '--[no-]verbose'], :flag, _('Be verbose (or not). True by default')
+  option ['--[no-]use-defaults'], :flag, _('Enable/disable stored defaults. Enabled by default')
   option ['-q', '--quiet'], :flag, _('Completely silent')
   option ["-d", "--debug"], :flag, "show debugging output"
   option ["-c", "--config"], "CFG_FILE", "path to custom config file" do |path|
@@ -83,6 +84,7 @@ HammerCLI::Settings.load({
     :interactive => preparser.interactive,
     :debug => preparser.debug?,
     :no_headers => preparser.no_headers?,
+    :use_defaults => preparser.use_defaults?,
     :reload_cache => preparser.reload_cache?,
     :verify_ssl => preparser.verify_ssl,
     :ssl_ca_file => preparser.ssl_ca_file,
@@ -91,6 +93,8 @@ HammerCLI::Settings.load({
     :ssl_client_key => preparser.ssl_client_key,
     :ssl_with_basic_auth => preparser.ssl_with_basic_auth?
   }})
+
+HammerCLI::Settings.load({:use_defaults => preparser.use_defaults?}) unless preparser.use_defaults?.nil?
 
 if HammerCLI::Settings.get(:ui, :mark_translated)
   include HammerCLI::I18n::Debug

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -33,7 +33,6 @@
 :verbosity: 2
 
 # Enable/disable defaults. Preset default values for the options won't be used.
-# Commands for handling the defaults will be disabled
 #:use_defaults: true
 
 #:log_owner: 'foreman'

--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -32,6 +32,10 @@
 #   2 - data, messages, interactive I/O, progress bars. Equals to --verbose.
 :verbosity: 2
 
+# Enable/disable defaults. Preset default values for the options won't be used.
+# Commands for handling the defaults will be disabled
+#:use_defaults: true
+
 #:log_owner: 'foreman'
 #:log_group: 'foreman'
 

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -245,10 +245,9 @@ module HammerCLI
 
 
     def option_sources
-      [
-        HammerCLI::Options::Sources::CommandLine.new(self),
-        HammerCLI::Options::Sources::SavedDefaults.new(context[:defaults], logger)
-      ]
+      sources = [HammerCLI::Options::Sources::CommandLine.new(self)]
+      sources << HammerCLI::Options::Sources::SavedDefaults.new(context[:defaults], logger) if context[:use_defaults]
+      sources
     end
 
     private

--- a/lib/hammer_cli/context.rb
+++ b/lib/hammer_cli/context.rb
@@ -7,6 +7,7 @@ module HammerCLI
       :is_tty? => HammerCLI.tty?,
       :api_connection => HammerCLI::Connection.new(Logging.logger['Connection']),
       :no_headers => HammerCLI::Settings.get(:ui, :no_headers),
+      :use_defaults => HammerCLI::Settings.get(:use_defaults),
       :capitalization => HammerCLI.capitalization,
       :verbosity => (HammerCLI::Settings.get(:verbosity) || HammerCLI::V_VERBOSE).to_i
     }

--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -10,7 +10,7 @@ module HammerCLI
 
     def initialize(settings, file_path = nil, enabled: HammerCLI::Settings.get(:use_defaults))
       @enabled = enabled
-      @defaults_settings = (enabled? ? settings : {}) || {}
+      @defaults_settings = settings || {}
       @path = file_path || DEFAULT_FILE
     end
 
@@ -61,7 +61,6 @@ module HammerCLI
     end
 
     def write_to_file(defaults)
-      ensure_is_enabled
       File.open(path,'w') do |h|
         h.write defaults.to_yaml
       end
@@ -72,7 +71,6 @@ module HammerCLI
     attr_reader :path
 
     def create_default_file
-      ensure_is_enabled
       if Dir.exist?(File.dirname(@path))
         new_file = File.new(path, "w")
         new_file.write ":defaults:"
@@ -102,14 +100,6 @@ module HammerCLI
 
     def switch_to_name(opt)
       opt.to_s.gsub(/^-[-]?/,'')
-    end
-
-    def ensure_is_enabled
-      unless enabled?
-        message = _('Modification of the defaults is not allowed when the feature is disabled.') +
-          "\n" + _('Use --use-defaults or enable defaults in CLI configuration to proceed.')
-        raise DefaultsError, message
-      end
     end
   end
 

--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -100,9 +100,13 @@ module HammerCLI
   end
 
   def self.defaults
-    @defaults ||= Defaults.new(HammerCLI::Settings.settings[:defaults])
-
+    return @defaults if @defaults
+    settings = HammerCLI::Settings
+    default_values = settings.get(:use_defaults) ? settings.get(:defaults) : {}
+    @defaults = Defaults.new(default_values)
   end
 
-  HammerCLI::MainCommand.subcommand "defaults", _("Defaults management"), HammerCLI::DefaultsCommand
+  if HammerCLI::Settings.get(:use_defaults)
+    HammerCLI::MainCommand.subcommand "defaults", _("Defaults management"), HammerCLI::DefaultsCommand
+  end
 end

--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -8,14 +8,18 @@ module HammerCLI
 
     attr_reader :defaults_settings
 
-    def initialize(settings, file_path = nil)
-
-      @defaults_settings = settings || {}
+    def initialize(settings, file_path = nil, enabled: HammerCLI::Settings.get(:use_defaults))
+      @enabled = enabled
+      @defaults_settings = (enabled? ? settings : {}) || {}
       @path = file_path || DEFAULT_FILE
     end
 
     def register_provider(provider)
       providers[provider.provider_name.to_s] = provider
+    end
+
+    def enabled?
+      !!@enabled
     end
 
     def providers
@@ -57,6 +61,7 @@ module HammerCLI
     end
 
     def write_to_file(defaults)
+      ensure_is_enabled
       File.open(path,'w') do |h|
         h.write defaults.to_yaml
       end
@@ -67,6 +72,7 @@ module HammerCLI
     attr_reader :path
 
     def create_default_file
+      ensure_is_enabled
       if Dir.exist?(File.dirname(@path))
         new_file = File.new(path, "w")
         new_file.write ":defaults:"
@@ -97,16 +103,19 @@ module HammerCLI
     def switch_to_name(opt)
       opt.to_s.gsub(/^-[-]?/,'')
     end
+
+    def ensure_is_enabled
+      unless enabled?
+        message = _('Modification of the defaults is not allowed when the feature is disabled.') +
+          "\n" + _('Use --use-defaults or enable defaults in CLI configuration to proceed.')
+        raise DefaultsError, message
+      end
+    end
   end
 
   def self.defaults
-    return @defaults if @defaults
-    settings = HammerCLI::Settings
-    default_values = settings.get(:use_defaults) ? settings.get(:defaults) : {}
-    @defaults = Defaults.new(default_values)
+    @defaults ||= Defaults.new(HammerCLI::Settings.get(:defaults))
   end
 
-  if HammerCLI::Settings.get(:use_defaults)
-    HammerCLI::MainCommand.subcommand "defaults", _("Defaults management"), HammerCLI::DefaultsCommand
-  end
+  HammerCLI::MainCommand.subcommand "defaults", _("Defaults management"), HammerCLI::DefaultsCommand
 end

--- a/lib/hammer_cli/defaults.rb
+++ b/lib/hammer_cli/defaults.rb
@@ -8,18 +8,13 @@ module HammerCLI
 
     attr_reader :defaults_settings
 
-    def initialize(settings, file_path = nil, enabled: HammerCLI::Settings.get(:use_defaults))
-      @enabled = enabled
+    def initialize(settings, file_path = nil)
       @defaults_settings = settings || {}
       @path = file_path || DEFAULT_FILE
     end
 
     def register_provider(provider)
       providers[provider.provider_name.to_s] = provider
-    end
-
-    def enabled?
-      !!@enabled
     end
 
     def providers

--- a/lib/hammer_cli/main.rb
+++ b/lib/hammer_cli/main.rb
@@ -10,6 +10,7 @@ module HammerCLI
     option ['-q', '--quiet'], :flag, _('Completely silent') do
       context[:verbosity] = HammerCLI::V_QUIET
     end
+    option ['--[no-]use-defaults'], :flag, _('Enable/disable stored defaults. Enabled by default')
     option ["-d", "--debug"], :flag, _("Show debugging output"), :context_target => :debug
     option ["-r", "--reload-cache"], :flag, _("Force reload of Apipie cache")
 

--- a/lib/hammer_cli/options/sources/saved_defaults.rb
+++ b/lib/hammer_cli/options/sources/saved_defaults.rb
@@ -8,11 +8,9 @@ module HammerCLI
         end
 
         def get_options(defined_options, result)
-          if @defaults && @defaults.enabled?
-            defined_options.each do |opt|
-              result[opt.attribute_name] = add_custom_defaults(opt) if result[opt.attribute_name].nil?
-            end
-          end
+          defined_options.each do |opt|
+            result[opt.attribute_name] = add_custom_defaults(opt) if result[opt.attribute_name].nil?
+          end if @defaults
           result
         end
 

--- a/lib/hammer_cli/options/sources/saved_defaults.rb
+++ b/lib/hammer_cli/options/sources/saved_defaults.rb
@@ -8,9 +8,11 @@ module HammerCLI
         end
 
         def get_options(defined_options, result)
-          defined_options.each do |opt|
-            result[opt.attribute_name] = add_custom_defaults(opt) if result[opt.attribute_name].nil?
-          end if @defaults
+          if @defaults && @defaults.enabled?
+            defined_options.each do |opt|
+              result[opt.attribute_name] = add_custom_defaults(opt) if result[opt.attribute_name].nil?
+            end
+          end
           result
         end
 

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -46,6 +46,11 @@ module HammerCLI
     end
 
     def self.clear
+      empty
+      load(default_values)
+    end
+
+    def self.empty
       settings.clear
       path_history.clear
     end
@@ -59,9 +64,16 @@ module HammerCLI
       @path_history
     end
 
+    def self.default_values
+      {
+        :use_defaults => true
+      }
+    end
+
     private
+
     def self.settings
-      @settings_hash ||= {}
+      @settings_hash ||= default_values
       @settings_hash
     end
 

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -47,7 +47,7 @@ module HammerCLI
 
     def self.clear
       empty
-      load(default_values)
+      load(default_settings)
     end
 
     def self.empty
@@ -64,7 +64,7 @@ module HammerCLI
       @path_history
     end
 
-    def self.default_values
+    def self.default_settings
       {
         :use_defaults => true
       }
@@ -73,7 +73,7 @@ module HammerCLI
     private
 
     def self.settings
-      @settings_hash ||= default_values
+      @settings_hash ||= default_settings
       @settings_hash
     end
 

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -373,12 +373,18 @@ describe HammerCLI::AbstractCommand do
     before do
       @defaults = mock()
       @defaults.stubs(:get_defaults).returns(nil)
-      @cmd = TestDefaultsCmd.new("", { :defaults => @defaults })
+      @cmd = TestDefaultsCmd.new("", { :defaults => @defaults, :use_defaults => true })
+      @cmd_no_defaults = TestDefaultsCmd.new("", { :defaults => @defaults, :use_defaults => false })
     end
 
     it 'provides default value for an option flag' do
       @defaults.expects(:get_defaults).with('--test').returns(2)
       assert_equal({'different_attr_name' => 2}, @cmd.options)
+    end
+
+    it 'does not set default value if the defaults are disabled' do
+      @defaults.expects(:get_defaults).never()
+      assert_equal({}, @cmd_no_defaults.options)
     end
 
     it 'prefers values from command line' do

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -75,7 +75,7 @@ describe HammerCLI::Settings do
     settings.clear
     settings.get(:a).must_be_nil
     settings.get(:b).must_be_nil
-    settings.default_values.each { |key, val| settings.get(key).must_equal val }
+    settings.default_settings.each { |key, val| settings.get(key).must_equal val }
   end
 
   it "empty wipes all settings including default values" do
@@ -86,7 +86,7 @@ describe HammerCLI::Settings do
 
   it "initializes settings with default settings" do
     settings.instance_variable_set(:@settings_hash, nil)
-    settings.dump.must_equal settings.default_values
+    settings.dump.must_equal settings.default_settings
   end
 
   context "load from paths" do

--- a/test/unit/settings_test.rb
+++ b/test/unit/settings_test.rb
@@ -44,6 +44,7 @@ describe HammerCLI::Settings do
   end
 
   it "dumps all settings" do
+    settings.empty
     data = {:a => 1, :b => 2}
     settings.load(data)
     settings.dump.must_equal data
@@ -69,11 +70,23 @@ describe HammerCLI::Settings do
     settings.get(:x).size.must_equal 4
   end
 
-  it "clear wipes all settings" do
+  it "clear wipes all settings but default values" do
     settings.load({:a => 1, :b => 2})
     settings.clear
     settings.get(:a).must_be_nil
     settings.get(:b).must_be_nil
+    settings.default_values.each { |key, val| settings.get(key).must_equal val }
+  end
+
+  it "empty wipes all settings including default values" do
+    settings.load({:a => 1, :b => 2})
+    settings.empty
+    settings.dump.must_equal({})
+  end
+
+  it "initializes settings with default settings" do
+    settings.instance_variable_set(:@settings_hash, nil)
+    settings.dump.must_equal settings.default_values
   end
 
   context "load from paths" do


### PR DESCRIPTION
Presence of Defaults can be set in cli_config.yml with
:use_defaults: true/false or on CLI with --use-defaults
--no-use-defaults respectively. both ways can be combined.
The value is propagated in the context as :use_defaults.
The defaults are enabled by default.

Hammer settings class was chenged so that it can be the single
source of default values which has three benefits
 - we don't have to fallback to default with every use of the value
 - we can keep the values commented out in config which makes it easier
to changelater
 - there is single place to look for the default setting