### PR TITLE
Refs #25724 - Fixed instructions in i18n docs

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -73,8 +73,8 @@ HammerCLI::I18n::FindTask.define(HammerCLIAwesome::I18n::LocaleDomain.new, Hamme
 and create `locale/Makefile` with following content:
 ```make
 DOMAIN = hammer-cli-awesome
-VERSION = $(shell bundle exec ruby -e 'require "rubygems"; spec = Gem::Specification::load("../hammer_cli_awesome.gemspec"); puts spec.version')
-MAIN_MAKEFILE = $(shell bundle exec ruby -e 'require "hammer_cli"; puts HammerCLI::I18n.main_makefile')
+VERSION = $(shell bundle exec ruby -C ../ -e 'require "rubygems"; spec = Gem::Specification::load("../hammer_cli_awesome.gemspec"); puts spec.version')
+MAIN_MAKEFILE = $(shell bundle exec ruby -C ../ -e 'require "hammer_cli"; puts HammerCLI::I18n.main_makefile')
 
 include $(MAIN_MAKEFILE)
 ```


### PR DESCRIPTION
The previous instructions didn't work with bundler when make was executed from ./locale/