### PR TITLE
Fixes #26120 - Extended capabilities for list type options

### DIFF
--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -39,6 +39,24 @@ module HammerCLI
         end
         extensions
       end
+
+      def extend_options_help(option)
+        extend_help do |h|
+          begin
+            h.find_item(:s_option_details)
+          rescue ArgumentError
+            option_details = HammerCLI::Help::Section.new(_('Option details'), nil, id: :s_option_details, richtext: true)
+            option_details.definition << HammerCLI::Help::Text.new(
+              _('Following parameters accept format defined by its schema (bold are required):')
+            )
+            h.definition.unshift(option_details)
+          ensure
+            h.find_item(:s_option_details).definition << HammerCLI::Help::List.new([
+              [option.switches.last, option.value_formatter.schema.description]
+            ])
+          end
+        end
+      end
     end
 
     def adapter
@@ -169,6 +187,7 @@ module HammerCLI
         declared_options << option
         block ||= option.default_conversion_block
         define_accessors_for(option, &block)
+        extend_options_help(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
       end
     end
 

--- a/lib/hammer_cli/apipie/option_builder.rb
+++ b/lib/hammer_cli/apipie/option_builder.rb
@@ -65,7 +65,11 @@ module HammerCLI::Apipie
       opts = {}
       opts[:required] = true if (param.required? and require_options?)
       if param.expected_type.to_s == 'array'
-        opts[:format] = HammerCLI::Options::Normalizers::List.new
+        if param.params.empty?
+          opts[:format] = HammerCLI::Options::Normalizers::List.new
+        else
+          opts[:format] = HammerCLI::Options::Normalizers::ListNested.new(param.params)
+        end
       elsif param.expected_type.to_s == 'boolean' || param.validator.to_s == 'boolean'
         opts[:format] = HammerCLI::Options::Normalizers::Bool.new
       elsif param.expected_type.to_s == 'string' && param.validator =~ /Must be one of: (.*)\./


### PR DESCRIPTION
Changes:
  - Added JSON support for `List` normalizer.
  - The option mentioned in the issue has [NestedValidator](https://github.com/Apipie/apipie-rails#nestedvalidator), so expected input is an array with hash objects. The plain `List` normalizer is good for simple lists (arrays). So, I've decided to create a mixed normalizer (`List` + `KeyValueList`) to handle this kind of options.
  - The help now contains `Option details` secion for each option of that sort, where user can see expected input generated from apidoc.
  - Added notification of JSON support to the help for each option that supports this kind of input.

Known bugs:
  - Because of simple regex in `KeyValueList` normalizer, there is no native support for more complicated input, like array of hashes or hash with an array as a value. That's why JSON support was added. 
