### PR TITLE
Fixes #25878 - New lines in text attr dont break output

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -469,13 +469,7 @@ directly with `puts` in Hammer. The reason is we separate definition
 of the output from its interpretation. Hammer uses so called _output adapters_
 that can modify the output format.
 
-Hammer comes with four basic output adapters:
-  * __base__   - simple output, structured records
-  * __table__  - records printed in tables, ideal for printing lists of records
-  * __csv__    - comma separated output, ideal for scripting and grepping
-  * __silent__ - no output, used for testing
-
-The detailed documentation on creating adapters is coming soon.
+The detailed documentation on adapters and related things is [here](output.md#adapters).
 
 #### Printing messages
 Very simple, just call
@@ -488,7 +482,7 @@ Typical usage of a CLI is interaction with some API. In many cases it's listing
 some records returned by the API.
 
 Hammer comes with support for selecting and formatting of hash record fields.
-You first create a _output definition_ that you apply to your data. The result
+You first create an _output definition_ that you apply to your data. The result
 is a collection of fields, each having its type. The collection is then passed to an
 _output adapter_ which handles the actual formatting and printing.
 

--- a/doc/developer_docs.md
+++ b/doc/developer_docs.md
@@ -8,6 +8,7 @@ before creating hammer specific plugins.
 Contents:
  - [Writing a plugin](writing_a_plugin.md#writing-your-own-hammer-plugin)
  - [Creating commands](creating_commands.md#create-your-first-command)
+ - [Output adapters, formatters, etc](output.md#output)
  - [Help modification](help_modification.md#modify-an-existing-help)
  - [Commands modification](commands_modification.md#modify-an-existing-command)
  - [Command extensions](commands_extension.md#extend-an-existing-command)

--- a/doc/output.md
+++ b/doc/output.md
@@ -1,0 +1,43 @@
+Output
+------------------------------
+
+### Adapters
+Output adapter is responsible for rendering the output in a specific way using
+__formatters__ (see below).
+Hammer comes with following adapters:
+  * __base__   - simple output, structured records
+  * __table__  - records printed in tables, ideal for printing lists of records
+  * __csv__    - comma separated output, ideal for scripting and grepping
+  * __yaml__   - YAML output
+  * __json__   - JSON output
+  * __silent__ - no output, used for testing
+
+### Formatters
+Formatter is a bit of code that can modify a representation of a field during
+output rendering. Formatter is registered for specific field type. Each field
+type can have multiple formatters.
+  * __ColorFormatter__    - colors data with a specific color
+  * __DateFormatter__     - formats a date string with `%Y/%m/%d %H:%M:%S` style
+  * __ListFormatter__     - formats an array of data with csv style
+  * __KeyValueFormatter__ - formats a hash with `key => value` style
+  * __BooleanFormatter__  - converts `1/0`/`true/false`/`""` to `"yes"`/`"no"`
+  * __LongTextFormatter__ - adds a new line at the start of the data string
+  * __InlineTextFormatter__    - removes all new lines from data string
+  * __MultilineTextFormatter__ - splits a long data string to fixed size chunks
+  with indentation
+
+### Formatter/Adapter features
+Currently used formatter (or adapter) features are of two kinds.
+The first one help us to align by structure of the output:
+  * __:serialized__ - means the fields are serialized into a string (__table__, __csv__, __base__ adapters)
+  * __:structured__ - means the output is structured  (__yaml__, __json__ adapters)
+  * __:inline__     - means that the value will be rendered into single line without newlines (__table__, __csv__ adapters)
+  * __:multiline__  - means that the properly indented value will be printed over multiple lines (__base__ adapter)
+
+The other kind serves to distinguish the cases where we can use the xterm colors
+to improve the output:
+  * __:rich_text__  - means we can use the xterm colors (__table__, __base__ adapters)
+  * __:plain_text__ - unused yet
+
+All the features the formatter has need to match (be present in) the adapter's
+features. Otherwise the formatter won't apply.

--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -3,7 +3,13 @@ module HammerCLI::Output::Adapter
   class Abstract
 
     def tags
-      []
+      %i[]
+    end
+
+    def features
+      return %i[] if tags.empty?
+
+      tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
     end
 
     def initialize(context={}, formatters={})
@@ -88,9 +94,9 @@ module HammerCLI::Output::Adapter
       formatters_map ||= {}
       formatters_map.inject({}) do |map, (type, formatter_list)|
         # remove incompatible formatters
-        filtered = formatter_list.select { |f| f.match?(tags) }
+        filtered = formatter_list.select { |f| f.match?(features) }
         # put serializers first
-        map[type] = filtered.sort_by { |f| f.tags.include?(:flat) ? 0 : 1 }
+        map[type] = filtered.sort_by { |f| f.required_features.include?(:serialized) ? 0 : 1 }
         map
       end
     end

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -4,8 +4,10 @@ module HammerCLI::Output::Adapter
     GROUP_INDENT = " "*4
     LABEL_DIVIDER = ": "
 
-    def tags
-      [:flat, :screen]
+    def features
+      return %i[serialized rich_text multiline] if tags.empty?
+
+      tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
     end
 
     def print_record(fields, record)

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -131,8 +131,10 @@ module HammerCLI::Output::Adapter
       @paginate_by_default = false
     end
 
-    def tags
-      [:flat]
+    def features
+      return %i[serialized inline] if tags.empty?
+
+      tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
     end
 
     def row_data(fields, collection)

--- a/lib/hammer_cli/output/adapter/table.rb
+++ b/lib/hammer_cli/output/adapter/table.rb
@@ -12,8 +12,10 @@ module HammerCLI::Output::Adapter
     LINE_SEPARATOR = '-|-'
     COLUMN_SEPARATOR = ' | '
 
-    def tags
-      [:screen, :flat]
+    def features
+      return %i[rich_text serialized inline] if tags.empty?
+
+      tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
     end
 
     def print_record(fields, record)

--- a/lib/hammer_cli/output/adapter/tree_structure.rb
+++ b/lib/hammer_cli/output/adapter/tree_structure.rb
@@ -6,10 +6,10 @@ module HammerCLI::Output::Adapter
       @paginate_by_default = false
     end
 
-    def tags
-      [
-        :data
-      ]
+    def features
+      return %i[structured] if tags.empty?
+
+      tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
     end
 
     def prepare_collection(fields, collection)

--- a/lib/hammer_cli/output/fields.rb
+++ b/lib/hammer_cli/output/fields.rb
@@ -89,6 +89,9 @@ module Fields
   class LongText < Field
   end
 
+  class Text < Field
+  end
+
   class KeyValue < Field
   end
 

--- a/lib/hammer_cli/output/utils.rb
+++ b/lib/hammer_cli/output/utils.rb
@@ -3,6 +3,17 @@ require 'unicode/display_width'
 module HammerCLI
   module Output
     module Utils
+      TAGS_MAPPING = {
+        flat: :serialized,
+        data: :structured,
+        screen: :rich_text,
+        file: :plain_text
+      }.freeze
+
+      def self.tag_to_feature(tag)
+        TAGS_MAPPING[tag]
+      end
+
       def self.real_length(value)
         decolorized = value.gsub(/\033\[[^m]*m/, '')
         Unicode::DisplayWidth.of(decolorized)

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -6,8 +6,8 @@ describe HammerCLI::Output::Adapter::Abstract do
   let(:adapter) { HammerCLI::Output::Adapter::Abstract.new }
 
 
-  it "should have tags" do
-    adapter.tags.must_be_kind_of Array
+  it "should have features" do
+    adapter.features.must_be_kind_of Array
   end
 
   class UnknownTestFormatter < HammerCLI::Output::Formatters::FieldFormatter
@@ -15,8 +15,8 @@ describe HammerCLI::Output::Adapter::Abstract do
       data+'.'
     end
 
-    def tags
-      [:unknown]
+    def required_features
+      %i[unknown]
     end
   end
 
@@ -24,7 +24,7 @@ describe HammerCLI::Output::Adapter::Abstract do
     adapter.paginate_by_default?.must_equal true
   end
 
-  it "should filter formatters with incompatible tags" do
+  it "should filter formatters with incompatible features" do
 
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [] })
     adapter = adapter_class.new({}, {:type => [UnknownTestFormatter.new]})
@@ -34,18 +34,18 @@ describe HammerCLI::Output::Adapter::Abstract do
     formatter = UnknownTestFormatter.new
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [formatter] })
     # set :unknown tag to abstract
-    adapter_class.any_instance.stubs(:tags).returns([:unknown])
+    adapter_class.any_instance.stubs(:features).returns([:unknown])
     adapter = adapter_class.new({}, {:type => [formatter]})
   end
 
   it "should put serializers first" do
     formatter1 = UnknownTestFormatter.new
-    formatter1.stubs(:tags).returns([])
+    formatter1.stubs(:required_features).returns([])
     formatter2 = UnknownTestFormatter.new
-    formatter2.stubs(:tags).returns([:flat])
+    formatter2.stubs(:required_features).returns([:serialized])
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [formatter2, formatter1] })
     # set :unknown tag to abstract
-    adapter_class.any_instance.stubs(:tags).returns([:flat])
+    adapter_class.any_instance.stubs(:features).returns([:serialized])
     adapter = adapter_class.new({}, {:type => [formatter1, formatter2]})
   end
 

--- a/test/unit/output/formatters_test.rb
+++ b/test/unit/output/formatters_test.rb
@@ -20,14 +20,14 @@ describe HammerCLI::Output::Formatters::FieldFormatter do
     formatter.respond_to?(:format).must_equal true
   end
 
-  it "has tags" do
-    formatter.tags.must_be_kind_of Array
+  it "has features" do
+    formatter.required_features.must_be_kind_of Array
   end
 
-  it "should know if it has matching tags" do
-    formatter.stubs(:tags).returns([:tag])
-    formatter.match?([:tag]).must_equal true
-    formatter.match?([:notag]).must_equal false
+  it "should know if it has matching features" do
+    formatter.stubs(:required_features).returns([:feature])
+    formatter.match?([:feature]).must_equal true
+    formatter.match?([:nofeature]).must_equal false
   end
 end
 
@@ -154,6 +154,49 @@ describe HammerCLI::Output::Formatters::LongTextFormatter do
     formatter.format("Some\nmultiline\ntext").must_equal "\nSome\nmultiline\ntext"
   end
 
+end
+
+describe HammerCLI::Output::Formatters::InlineTextFormatter do
+  let(:formatter) { HammerCLI::Output::Formatters::InlineTextFormatter.new }
+
+  it 'prints multiline text to one line' do
+    formatter.format("Some\nmultiline\ntext").must_equal('Some multiline text')
+  end
+
+  it 'accepts nil' do
+    formatter.format(nil).must_equal('')
+  end
+end
+
+describe HammerCLI::Output::Formatters::MultilineTextFormatter do
+  let(:formatter) { HammerCLI::Output::Formatters::MultilineTextFormatter.new }
+  let(:multiline_text) { "Some\nmultiline\ntext" }
+  let(:indentation) { "\n    " }
+  let(:long_multiline_text) { 'Lorem ipsum dolor' * 5 }
+
+  it 'prints multiline text' do
+    formatter.format(multiline_text).must_equal(
+      "#{indentation}Some#{indentation}multiline#{indentation}text"
+    )
+  end
+
+  it 'accepts nil' do
+    formatter.format(nil).must_equal(indentation)
+  end
+
+  it 'accepts field width param' do
+    formatter.format(long_multiline_text, width: 80)
+             .must_equal(indentation + long_multiline_text[0..-6] +
+                         indentation + long_multiline_text[-5..-1])
+  end
+
+  it 'deals with strange params' do
+    formatter.format(long_multiline_text, width: -1)
+             .must_equal(indentation + long_multiline_text[0..-26] +
+                         indentation + long_multiline_text[-25..-1])
+    formatter.format(long_multiline_text, width: 999)
+             .must_equal(indentation + long_multiline_text)
+  end
 end
 
 describe HammerCLI::Output::Formatters::BooleanFormatter do


### PR DESCRIPTION
The fix adds a possibility to print long text (e.g. descriptions) with line breakers into one line. Simply changes new lines into spaces. This can be achieved with `inline: true` option for `LongText` field.

JSON and YAML output is not changed, since all whitespaces are escaped there.