### PR TITLE
Fixes #24964 - Document how to deprecate commands

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -435,7 +435,34 @@ HammerCLI::MainCommand.lazy_subcommand(
 )
 ```
 
+### Deprecated commands
+To mark a command as deprecated use the `:warning` option as follows:
 
+```ruby
+HammerCLI::MainCommand.lazy_subcommand(
+  'say',                        # command's name
+  'Say something',              # description
+  'HammerCLIHello::SayCommand', # command's class in a string
+  'hammer_cli_hello/say',       # require path of the file
+  warning: _('This command is deprecated and will be removed.')
+)
+```
+Or you can mark a command in its definition:
+
+```ruby
+class SayCommand < HammerCLI::AbstractCommand
+
+  class HelloCommand < HammerCLI::AbstractCommand
+    deprecation 'This command is deprecated and will be removed.'
+    command_name 'hello'
+    desc 'Say Hello World!'
+    # ...
+  end
+  # ...
+
+  autoload_subcommands
+end
+```
 ### Printing some output
 We've mentioned above that it's not recommended practice to print output
 directly with `puts` in Hammer. The reason is we separate definition

--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -453,7 +453,7 @@ Or you can mark a command in its definition:
 class SayCommand < HammerCLI::AbstractCommand
 
   class HelloCommand < HammerCLI::AbstractCommand
-    deprecation 'This command is deprecated and will be removed.'
+    warning 'This command is deprecated and will be removed.'
     command_name 'hello'
     desc 'Say Hello World!'
     # ...

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -226,15 +226,15 @@ module HammerCLI
       @name || (superclass.respond_to?(:command_name) ? superclass.command_name : nil)
     end
 
-    def self.deprecation(message = nil)
-      @deprecation_msg = message if message
-      @deprecation_msg
+    def self.warning(message = nil)
+      @warning_msg = message if message
+      @warning_msg
     end
 
     def self.autoload_subcommands
       commands = constants.map { |c| const_get(c) }.select { |c| c <= HammerCLI::AbstractCommand }
       commands.each do |cls|
-        subcommand(cls.command_name, cls.desc, cls, warning: cls.deprecation)
+        subcommand(cls.command_name, cls.desc, cls, warning: cls.warning)
       end
     end
 

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -226,10 +226,15 @@ module HammerCLI
       @name || (superclass.respond_to?(:command_name) ? superclass.command_name : nil)
     end
 
+    def self.deprecation(message = nil)
+      @deprecation_msg = message if message
+      @deprecation_msg
+    end
+
     def self.autoload_subcommands
       commands = constants.map { |c| const_get(c) }.select { |c| c <= HammerCLI::AbstractCommand }
       commands.each do |cls|
-        subcommand cls.command_name, cls.desc, cls
+        subcommand(cls.command_name, cls.desc, cls, warning: cls.deprecation)
       end
     end
 

--- a/lib/hammer_cli/subcommand.rb
+++ b/lib/hammer_cli/subcommand.rb
@@ -18,6 +18,7 @@ module HammerCLI
       end
 
       def subcommand_class
+        @warning ||= @subcommand_class.deprecation
         warn(@warning) if @warning
         @subcommand_class
       end
@@ -38,12 +39,13 @@ module HammerCLI
       end
 
       def subcommand_class
-        warn(@warning) if @warning
-        if !@loaded
+        unless @loaded
           require @path
           @loaded = true
           @constantized_class = @subcommand_class.constantize
         end
+        @warning ||= @constantized_class.deprecation
+        warn(@warning) if @warning
         @constantized_class
       end
     end

--- a/lib/hammer_cli/subcommand.rb
+++ b/lib/hammer_cli/subcommand.rb
@@ -18,7 +18,7 @@ module HammerCLI
       end
 
       def subcommand_class
-        @warning ||= @subcommand_class.deprecation
+        @warning ||= @subcommand_class.warning
         warn(@warning) if @warning
         @subcommand_class
       end
@@ -44,7 +44,7 @@ module HammerCLI
           @loaded = true
           @constantized_class = @subcommand_class.constantize
         end
-        @warning ||= @constantized_class.deprecation
+        @warning ||= @constantized_class.warning
         warn(@warning) if @warning
         @constantized_class
       end


### PR DESCRIPTION
Except documentation the fix adds a way to mark a command as deprecated in its definition (in case of subcommand autoloading):

```ruby
class Command < HammerCLI::AbstractCommand
  deprecation 'This command is deprecated.'
  # ...
  def execute
    # ...
  end
end
```