### PR TITLE
Fixes #26961 - Filter fields properly

### DIFF
--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -92,7 +92,7 @@ module HammerCLI::Output::Adapter
     end
 
     def sets_filter
-      @context[:fields] || []
+      @context[:fields] || ['DEFAULT']
     end
 
     private

--- a/lib/hammer_cli/output/field_filter.rb
+++ b/lib/hammer_cli/output/field_filter.rb
@@ -65,12 +65,9 @@ module HammerCLI::Output
     end
 
     def include_by_label?(labels, label)
-      return true if labels.include?(label)
-
-      labels.each do |l|
-        return true if l.start_with?("#{label}/") || label.start_with?(l)
+      labels.any? do |l|
+        l.start_with?("#{label}/") || label.match(%r{^#{l.gsub(/\*/, '.*')}(|\/.*)$})
       end
-      false
     end
 
     def resolve_set_names(sets)

--- a/lib/hammer_cli/output/fields.rb
+++ b/lib/hammer_cli/output/fields.rb
@@ -32,7 +32,7 @@ module Fields
     end
 
     def full_label
-      return @label if @parent.nil?
+      return @label.to_s if @parent.nil?
       "#{@parent.full_label}/#{@label}"
     end
 

--- a/test/unit/output/field_filter_test.rb
+++ b/test/unit/output/field_filter_test.rb
@@ -47,7 +47,17 @@ describe HammerCLI::Output::FieldFilter do
 
   it 'filters by full labels' do
     f = HammerCLI::Output::FieldFilter.new(container_fields, sets_filter: ['container/first'])
-    f.filter_by_sets.filtered_fields.map(&:label).must_equal ['container']
+    f.filter_by_sets.filtered_fields.first.fields.map(&:label).must_equal ['first']
+  end
+
+  it 'filters by superclass labels' do
+    f = HammerCLI::Output::FieldFilter.new(container_fields, sets_filter: ['container'])
+    f.filter_by_sets.filtered_fields.first.fields.map(&:label).must_equal ['first', 'second']
+  end
+
+  it 'filters by labels with wildcards' do
+    f = HammerCLI::Output::FieldFilter.new(container_fields, sets_filter: ['container/f*'])
+    f.filter_by_sets.filtered_fields.first.fields.map(&:label).must_equal ['first']
   end
 
   it 'allows chained filtering' do


### PR DESCRIPTION
This patch makes filtering by label more strict.
- exact match is required
- wildcard supported (just '*' at the and)
- only fields from the DEFAULT set printed by default