### PR TITLE
Fixes #17819 - Allow adapters print page by page

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -494,6 +494,33 @@ You first create an _output definition_ that you apply to your data. The result
 is a collection of fields, each having its type. The collection is then passed to an
 _output adapter_ which handles the actual formatting and printing.
 
+Adapters support printing by chunks, e.g. if you want to print a large set of
+data (1000+ records), but you make several calls to the server instead of one,
+you may want to print received data right away instead of waiting for the rest.
+This can be achieved via `:current_chunk` option for
+`print_collection` and `print_data` methods. Allowed values for `:current_chunk`
+are `:first`, `:another`, `:last`. By default adapters use `:single` value that
+means only one record will be printed.
+
+##### Printing by chunks
+```ruby
+# ...
+  def execute
+    loop do
+      # ...
+      data = send_request
+      print_data(data, current_chunk: :first)
+      # ...
+      data = send_request
+      print_data(data, current_chunk: :another)
+      # ...
+      data = send_request
+      print_data(data, current_chunk: :last)
+    end
+  end
+# ...
+```
+
 Hammer provides a DSL for defining the output. Next rather complex example will
 explain how to use it in action.
 

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -74,6 +74,7 @@ module HammerCLI
       begin
         begin
           exit_code = super
+          context.delete(:fields)
           raise "exit code must be integer" unless exit_code.is_a? Integer
         rescue => e
           exit_code = handle_exception(e)
@@ -242,8 +243,8 @@ module HammerCLI
       output.print_record(definition, record)
     end
 
-    def print_collection(definition, collection)
-      output.print_collection(definition, collection)
+    def print_collection(definition, collection, options = {})
+      output.print_collection(definition, collection, options)
     end
 
     def print_message(msg, msg_params = {}, options = {})

--- a/lib/hammer_cli/apipie/command.rb
+++ b/lib/hammer_cli/apipie/command.rb
@@ -65,8 +65,8 @@ module HammerCLI::Apipie
       method_options(options)
     end
 
-    def print_data(data)
-      print_collection(output_definition, data) unless output_definition.empty?
+    def print_data(data, options = {})
+      print_collection(output_definition, data, options) unless output_definition.empty?
       print_success_message(data) unless success_message.nil?
     end
 

--- a/lib/hammer_cli/output/adapter/abstract.rb
+++ b/lib/hammer_cli/output/adapter/abstract.rb
@@ -44,12 +44,8 @@ module HammerCLI::Output::Adapter
       raise NotImplementedError
     end
 
-    def print_collection(fields, collection)
+    def print_collection(fields, collection, options = {})
       raise NotImplementedError
-    end
-
-    def reset_context
-      @context.delete(:fields)
     end
 
     protected

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -14,7 +14,7 @@ module HammerCLI::Output::Adapter
       print_collection(fields, [record].flatten(1))
     end
 
-    def print_collection(fields, collection)
+    def print_collection(fields, collection, options = {})
       collection.each do |data|
         output_stream.puts render_fields(fields, data)
         output_stream.puts

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -149,7 +149,8 @@ module HammerCLI::Output::Adapter
       print_collection(fields, [record].flatten(1))
     end
 
-    def print_collection(fields, collection)
+    def print_collection(fields, collection, options = {})
+      current_chunk = options[:current_chunk] || :single
       fields = filter_fields(fields).filter_by_classes
                                     .filter_by_sets
                                     .filter_by_data(collection.first,
@@ -161,7 +162,7 @@ module HammerCLI::Output::Adapter
       # or use headers from output definition
       headers ||= default_headers(fields)
       csv_string = generate do |csv|
-        csv << headers if headers && !@context[:no_headers]
+        csv << headers if headers && !@context[:no_headers] && %i[first single].include?(current_chunk)
         rows.each do |row|
           csv << Cell.values(headers, row)
         end

--- a/lib/hammer_cli/output/adapter/json.rb
+++ b/lib/hammer_cli/output/adapter/json.rb
@@ -6,9 +6,20 @@ module HammerCLI::Output::Adapter
       output_stream.puts JSON.pretty_generate(result.first)
     end
 
-    def print_collection(fields, collection)
-      result = prepare_collection(fields, collection)
-      output_stream.puts JSON.pretty_generate(result)
+    def print_collection(fields, collection, options = {})
+      current_chunk = options[:current_chunk] || :single
+      prepared = prepare_collection(fields, collection)
+      result = JSON.pretty_generate(prepared)
+      if current_chunk != :single
+        result = if current_chunk == :first
+                   result[0...-2] + ','
+                 elsif current_chunk == :last
+                   result[2..-1]
+                 else
+                   result[2...-2] + ','
+                 end
+      end
+      output_stream.puts result
     end
 
     def print_message(msg, msg_params={})

--- a/lib/hammer_cli/output/adapter/silent.rb
+++ b/lib/hammer_cli/output/adapter/silent.rb
@@ -12,7 +12,7 @@ module HammerCLI::Output::Adapter
     def print_record(fields, record)
     end
 
-    def print_collection(fields, collection)
+    def print_collection(fields, collection, options = {})
     end
 
   end

--- a/lib/hammer_cli/output/adapter/yaml.rb
+++ b/lib/hammer_cli/output/adapter/yaml.rb
@@ -6,9 +6,12 @@ module HammerCLI::Output::Adapter
       output_stream.puts YAML.dump(result.first)
     end
 
-    def print_collection(fields, collection)
-      result = prepare_collection(fields, collection)
-      output_stream.puts YAML.dump(result)
+    def print_collection(fields, collection, options = {})
+      current_chunk = options[:current_chunk] || :single
+      prepared = prepare_collection(fields, collection)
+      result = YAML.dump(prepared)
+      result = result[4..-1] unless %i[first single].include?(current_chunk)
+      output_stream.puts result
     end
 
     def print_message(msg, msg_params={})

--- a/lib/hammer_cli/output/output.rb
+++ b/lib/hammer_cli/output/output.rb
@@ -25,15 +25,13 @@ module HammerCLI::Output
 
     def print_record(definition, record)
       adapter.print_record(definition.fields, record) if appropriate_verbosity?(:record)
-      adapter.reset_context
     end
 
-    def print_collection(definition, collection)
+    def print_collection(definition, collection, options = {})
       unless collection.class <= HammerCLI::Output::RecordCollection
         collection = HammerCLI::Output::RecordCollection.new([collection].flatten(1))
       end
-      adapter.print_collection(definition.fields, collection) if appropriate_verbosity?(:collection)
-      adapter.reset_context
+      adapter.print_collection(definition.fields, collection, options) if appropriate_verbosity?(:collection)
     end
 
     def adapter

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -9,7 +9,7 @@ describe HammerCLI::Output::Adapter::CSValues do
   end
 
   context "print_collection" do
-
+    let(:field_id) { Fields::Id.new(:path => [:id], :label => "Id") }
     let(:field_name) { Fields::Field.new(:path => [:name], :label => "Name") }
     let(:field_started_at) { Fields::Field.new(:path => [:started_at], :label => "Started At") }
     let(:field_login) { Fields::Field.new(:path => [:login], :label => "Login") }
@@ -217,6 +217,68 @@ describe HammerCLI::Output::Adapter::CSValues do
         nil_data = HammerCLI::Output::RecordCollection.new [{ :name => nil }]
         out, err = capture_io { adapter.print_collection([field_name], nil_data) }
         out.must_match(/.*NIL.*/)
+      end
+    end
+
+    context 'printing by chunks' do
+      let(:adapter) { HammerCLI::Output::Adapter::CSValues.new(show_ids: true) }
+      let(:collection_count) { 30 }
+      let(:collection_data) do
+        collection = collection_count.times.each_with_object([]) do |t, r|
+          r << { id: t, name: "John #{t}"}
+        end
+        HammerCLI::Output::RecordCollection.new(collection)
+      end
+      let(:fields) { [field_id, field_name] }
+
+      it 'prints single chunk' do
+        expected_output = collection_count.times.each_with_object([]) do |t, r|
+          r << ["#{t}", "John #{t}"].join(',')
+        end.flatten(1).unshift('Id,Name').join("\n") + "\n"
+
+        out, _err = capture_io do
+          adapter.print_collection(fields, collection_data)
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'prints first chunk' do
+        expected_output = 10.times.each_with_object([]) do |t, r|
+          r << ["#{t}", "John #{t}"].join(',')
+        end.flatten(1).unshift('Id,Name').join("\n") + "\n"
+
+        out, _err = capture_io do
+          adapter.print_collection(
+            fields, collection_data[0...10], current_chunk: :first
+          )
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'prints another chunk' do
+        expected_output = (10...20).each_with_object([]) do |t, r|
+          r << ["#{t}", "John #{t}"].join(',')
+        end.flatten(1).join("\n") + "\n"
+
+        out, _err = capture_io do
+          adapter.print_collection(
+            fields, collection_data[10...20], current_chunk: :another
+          )
+        end
+        out.must_equal(expected_output)
+      end
+
+      it 'prints last chunk' do
+        expected_output = (20...30).each_with_object([]) do |t, r|
+          r << ["#{t}", "John #{t}"].join(',')
+        end.flatten(1).join("\n") + "\n"
+
+        out, _err = capture_io do
+          adapter.print_collection(
+            fields, collection_data[20...30], current_chunk: :last
+          )
+        end
+        out.must_equal(expected_output)
       end
     end
 

--- a/test/unit/output/output_test.rb
+++ b/test/unit/output/output_test.rb
@@ -58,19 +58,19 @@ describe HammerCLI::Output::Output do
     end
 
     it "prints single resource as collection" do
-      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection))
+      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection), {})
       out.print_collection(definition, item1)
     end
 
 
     it "prints array of resources" do
-      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection))
+      adapter.any_instance.expects(:print_collection).with([], instance_of(HammerCLI::Output::RecordCollection), {})
       out.print_collection(definition, collection)
     end
 
     it "prints recordset" do
       data = HammerCLI::Output::RecordCollection.new(collection)
-      adapter.any_instance.expects(:print_collection).with([], data)
+      adapter.any_instance.expects(:print_collection).with([], data, {})
       out.print_collection(definition, data)
     end
 


### PR DESCRIPTION
TODO:
 - [x] Remove --fields arguments from command context after its invocation.
 - [x] Add tests.
 - [x] ~~Add an explanation of `current_chunk` method~~ Explain `current_chunk` option.