### PR TITLE
Fixes #27595 - Better prompts for missing arguments

### DIFF
--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -138,7 +138,16 @@ module HammerCLI
     end
 
     def handle_apipie_missing_arguments_error(e)
-      message = _("Missing arguments for %s") % "'#{e.params.join("', '")}'"
+      params = e.params.map do |p|
+        param = p[/\[.+\]/]
+        param = if param.nil?
+                  p
+                else
+                  p.scan(/\[[^\[\]]+\]/).first[1...-1].tr('_', '-')
+                end
+        "--#{param}"
+      end
+      message = _("Missing arguments for %s") % "'#{params.uniq.join("', '")}'"
       print_error message
       log_full_error e, message
       HammerCLI::EX_USAGE

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -55,4 +55,40 @@ describe HammerCLI::ExceptionHandler do
     assert_match /ERROR  Exception : (Resource )?Not Found/, @log_output.readline.strip
   end
 
+  it "should print default prompts for standard missing arguments" do
+    params = %w[login mail]
+    heading = 'Could not create user:'
+    body = "Missing arguments for '--login', '--mail'"
+    ex = ApipieBindings::MissingArgumentsError.new(params)
+    output.expects(:print_error).with(heading, body)
+    handler.handle_exception(ex, heading: heading)
+  end
+
+  it "should print right prompts for nested missing arguments" do
+    params = %w[user[login] user[mail]]
+    heading = 'Could not create user:'
+    body = "Missing arguments for '--login', '--mail'"
+    ex = ApipieBindings::MissingArgumentsError.new(params)
+    output.expects(:print_error).with(heading, body)
+    handler.handle_exception(ex, heading: heading)
+  end
+
+  it "should print simple prompts for even more nested arguments" do
+    params = %w[user[address][city] user[address][street]]
+    heading = 'Could not create user:'
+    body = "Missing arguments for '--address'"
+    ex = ApipieBindings::MissingArgumentsError.new(params)
+    output.expects(:print_error).with(heading, body)
+    handler.handle_exception(ex, heading: heading)
+  end
+
+  it "should print simple prompts for even more different nested arguments" do
+    params = %w[user[address][city] user[address][street] user[nested][par1]]
+    heading = 'Could not create user:'
+    body = "Missing arguments for '--address', '--nested'"
+    ex = ApipieBindings::MissingArgumentsError.new(params)
+    output.expects(:print_error).with(heading, body)
+    handler.handle_exception(ex, heading: heading)
+  end
+
 end


### PR DESCRIPTION
Changes prompts like
```
Missing arguments for 'foreman_virt_who_configure_config[hypervisor_username]'
```
to (as per help)
```
Missing arguments for '--hypervisor-username'
```