### PR TITLE
Fixes #28440 - Help contains squeezed options

### DIFF
--- a/doc/commands_extension.md
+++ b/doc/commands_extension.md
@@ -10,6 +10,11 @@ Each command can be easily extended with one ore more `HammerCLI::CommandExtensi
     inheritable true
     # Simply add a new option to a command is being extended
     option(option_params)
+    # Add option family to a command
+    option_family(common_options = {}) do
+      parent option_params
+      child option_params
+    end
     # Extend hash with data returned from server before it is printed
     before_print do |data|
       # data modifications
@@ -64,6 +69,13 @@ __NOTE:__
 class MyCommandExtensions < HammerCLI::CommandExtensions
 
   option ['--new-option'], 'TYPE', _('Option description')
+
+  option_family(
+    description: _('Common description')
+  ) do
+    parent ['--new-option'], 'TYPE', _('Option description')
+    child ['--new-option-ver2'], 'TYPE', _('Option description')
+  end
 
   before_print do |data|
     data['results'].each do |result|

--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -173,6 +173,54 @@ Here is the list of predefined options:
   * `:fields` Expects a list with fields to show in output, see [example](creating_commands.md#printing-hash-records).
 
 
+### Option family
+Option family is the way to unify options which have the same meaning or purpose,
+but contain some differences in their definitions (e.g. the name/switch of an option).
+Mainly serves as a container for options, which purpose is to show less repetitive
+output in commands' help. Option builders use it by default.
+
+To define an option family, use the following DSL:
+```ruby
+  # options is a Hash with options for family/each defined option within it
+  option_family(options = {}) do
+    # parent is the main option. Must be single, option family can have only one parent.
+    parent switches, type, description, options
+    # child  is an additional option. Could be none or more than one. Aren't shown in the help output.
+    child  switches, type, description, options
+  end
+```
+
+##### Example
+
+```ruby
+  option_family(
+    aliased_resource: 'environment',
+    description: _('Puppet environment'),
+    deprecation: _("Use %s instead") % '--puppet-environment[-id]'
+    deprecated: { '--environment' => _("Use %s instead") % '--puppet-environment[-id]',
+                  '--environment-id' => _("Use %s instead") % '--puppet-environment[-id]'}
+  ) do
+    parent '--environment-id', 'ENVIRONMENT_ID', _(''),
+           format: HammerCLI::Options::Normalizers::Number.new,
+           attribute_name: :option_environment_id
+    child '--environment', 'ENVIRONMENT_NAME', _('Environment name'),
+          attribute_name: :option_environment_name
+  end
+
+  # $ hammer command --help:
+  # ...
+  #  Options:
+  #    --environment[-id]               Puppet environment (Deprecated: Use --puppet-environment[-id] instead)
+  # ...
+
+  # $ hammer full-help:
+  # ...
+  #  Options:
+  #    --environment   ENVIRONMENT_NAME    Environment name (--environment is deprecated: Use --puppet-environment[-id] instead)
+  #    --environment-id   ENVIRONMENT_ID    (--environment-id is deprecated: Use --puppet-environment[-id] instead)
+  # ...
+```
+
 ### Option builders
 Hammer commands offer option builders that can be used for automatic option generation.
 See [documentation page](option_builders.md#option-builders) dedicated to this topic for more details.

--- a/lib/hammer_cli/apipie/option_definition.rb
+++ b/lib/hammer_cli/apipie/option_definition.rb
@@ -1,19 +1,23 @@
 require File.join(File.dirname(__FILE__), 'options')
 
 module HammerCLI::Apipie
-
   class OptionDefinition < HammerCLI::Options::OptionDefinition
-
-    attr_accessor :referenced_resource
+    attr_accessor :referenced_resource, :aliased_resource, :family
 
     def initialize(switches, type, description, options = {})
       @referenced_resource = options[:referenced_resource].to_s if options[:referenced_resource]
+      @aliased_resource = options[:aliased_resource].to_s if options[:aliased_resource]
+      @family = options[:family]
       super
       # Apipie currently sends descriptions as escaped HTML once this is changed this should be removed.
       # See #15198 on Redmine.
       @description = CGI::unescapeHTML(description)
     end
 
-  end
+    def child?
+      return unless @family
 
+      @family.children.include?(self)
+    end
+  end
 end

--- a/lib/hammer_cli/full_help.rb
+++ b/lib/hammer_cli/full_help.rb
@@ -6,8 +6,10 @@ module HammerCLI
 
     def execute
       @adapter = option_md? ? MDAdapter.new : TxtAdapter.new
+      HammerCLI.context[:full_help] = true
       print_heading
       print_help
+      HammerCLI.context[:full_help] = false
       HammerCLI::EX_OK
     end
 

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -29,12 +29,19 @@ module HammerCLI
 
         label_width = DEFAULT_LABEL_INDENT
         items.each do |item|
-          label, description = item.help
+          label = item.help.first
           label_width = label.size if label.size > label_width
         end
 
         items.each do |item|
-          label, description = item.help
+          if item.respond_to?(:child?) && item.child?
+            next unless HammerCLI.context[:full_help]
+          end
+          label, description = if !HammerCLI.context[:full_help] && item.respond_to?(:family) && item.family
+            [item.family.switch, item.family.description || item.help[1]]
+          else
+            item.help
+          end
           description.gsub(/^(.)/) { Unicode::capitalize($1) }.each_line do |line|
             puts " %-#{label_width}s %s" % [label, line]
             label = ''

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -22,14 +22,12 @@ module HammerCLI
 
     class OptionDefinition < Clamp::Option::Definition
 
-      attr_accessor :value_formatter
-      attr_accessor :context_target
-      attr_accessor :deprecated_switches
+      attr_accessor :value_formatter, :context_target, :deprecated_switches
 
       def initialize(switches, type, description, options = {})
-        self.value_formatter = options[:format] || HammerCLI::Options::Normalizers::Default.new
-        self.context_target = options[:context_target]
-        self.deprecated_switches = options[:deprecated]
+        @value_formatter = options[:format] || HammerCLI::Options::Normalizers::Default.new
+        @context_target = options[:context_target]
+        @deprecated_switches = options[:deprecated]
         super
       end
 

--- a/lib/hammer_cli/options/option_family.rb
+++ b/lib/hammer_cli/options/option_family.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module HammerCLI
+  module Options
+    class OptionFamily
+      attr_reader :children
+
+      IDS_REGEX = /\s?([Ii][Dd][s]?)\W|([Ii][Dd][s]?\Z)/
+
+      def initialize(options = {})
+        @all = []
+        @children = []
+        @options = options
+        @creator = options[:creator] || Class.new(HammerCLI::Apipie::Command)
+        @prefix = options[:prefix]
+        @description = options[:description]
+        @root = options[:root] || options[:aliased_resource] || options[:referenced_resource]
+      end
+
+      def description
+        types = all.map(&:type).map { |s| s.split('_').last.to_s }
+                   .map(&:capitalize).join('/')
+        @description ||= @parent.help[1].gsub(IDS_REGEX) { |w| w.gsub(/\w+/, types) }
+        if @options[:deprecation].class <= String
+          format_deprecation_msg(@description, _('Deprecated: %{deprecated_msg}') % { deprecated_msg: @options[:deprecation] })
+        elsif @options[:deprecation].class <= Hash
+          full_msg = @options[:deprecation].map do |flag, msg|
+            _('%{flag} is deprecated: %{deprecated_msg}') % { flag: flag, deprecated_msg: msg }
+          end.join(', ')
+          format_deprecation_msg(@description, full_msg)
+        else
+          @description
+        end
+      end
+
+      def switch
+        return if @parent.nil? && @children.empty?
+        return @parent.help_lhs.strip if @children.empty?
+
+        switch_start = main_switch.each_char
+                                  .zip(*all.map(&:switches).flatten.map(&:each_char))
+                                  .select { |a, b| a == b }.transpose.first.join
+        suffixes = all.map do |m|
+          m.switches.map { |s| s.gsub(switch_start, '') }
+        end.flatten.reject(&:empty?).sort { |x, y| x.size <=> y.size }
+        "#{switch_start}[#{suffixes.join('|')}]"
+      end
+
+      def head
+        @parent
+      end
+
+      def all
+        @children + [@parent].compact
+      end
+
+      def parent(switches, type, description, opts = {}, &block)
+        raise StandardError, 'Option family can have only one parent' if @parent
+
+        @parent = new_member(switches, type, description, opts, &block)
+      end
+
+      def child(switches, type, description, opts = {}, &block)
+        child = new_member(switches, type, description, opts, &block)
+        @children << child
+        child
+      end
+
+      def adopt(child)
+        child.family = self
+        @children << child
+      end
+
+      private
+
+      def format_deprecation_msg(option_desc, deprecation_msg)
+        "#{option_desc} (#{deprecation_msg})"
+      end
+
+      def new_member(switches, type, description, opts = {}, &block)
+        opts = opts.merge(@options)
+        opts[:family] = self
+        if opts[:deprecated]
+          handles = [switches].flatten
+          opts[:deprecated] = opts[:deprecated].select do |switch, _msg|
+            handles.include?(switch)
+          end
+        end
+        @creator.instance_eval do
+          option(switches, type, description, opts, &block)
+        end
+      end
+
+      def main_switch
+        root = @root || @parent.aliased_resource || @parent.referenced_resource || common_root
+        "--#{@prefix}#{root}".tr('_', '-')
+      end
+
+      def common_root
+        switches = all.map(&:switches).flatten
+        shortest = switches.min_by(&:length)
+        max_len = shortest.length
+        max_len.downto(0) do |curr_len|
+          0.upto(max_len - curr_len) do |start|
+            root = shortest[start, curr_len]
+            if switches.all? { |switch| switch.include?(root) }
+              return root[2..-1].chomp('-')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -37,6 +37,14 @@ describe HammerCLI::Apipie::OptionBuilder do
     it "should set description with html tags stripped" do
       options[0].description.must_equal 'filter results'
     end
+
+    it "should build option with default family" do
+      options[0].family.wont_be_nil
+    end
+
+    it "should build parent option within default family" do
+      options[0].child?.must_equal false
+    end
   end
 
 

--- a/test/unit/command_extensions_test.rb
+++ b/test/unit/command_extensions_test.rb
@@ -23,6 +23,12 @@ describe HammerCLI::CommandExtensions do
 
   class CmdExtensions < HammerCLI::CommandExtensions
     option '--ext', 'EXT', 'ext'
+    option_family(
+      description: 'Test',
+    ) do
+      parent '--test-one', '', ''
+      child '--test-two', '', ''
+    end
     before_print do |data|
       data['key'] = 'value'
     end
@@ -108,6 +114,12 @@ describe HammerCLI::CommandExtensions do
       cmd.new({}).extended_request[2].must_equal({})
       cmd.new({}).extended_data({}).must_equal('key' => 'value')
     end
+
+    it 'should extend option family only' do
+      cmd.extend_with(CmdExtensions.new(only: :option_family))
+      cmd.output_definition.empty?.must_equal true
+      cmd.recognised_options.map(&:switches).flatten.must_equal ['--test-one', '--test-two', '-h', '--help']
+    end
   end
 
   context 'except' do
@@ -182,6 +194,12 @@ describe HammerCLI::CommandExtensions do
       cmd.new({}).extended_request[1].must_equal(ssl: true)
       cmd.new({}).extended_request[2].must_equal(with_authentication: true)
       cmd.new({}).extended_data({}).must_equal({})
+    end
+
+    it 'should extend all except option family' do
+      cmd.extend_with(CmdExtensions.new(except: :option_family))
+      cmd.output_definition.empty?.must_equal false
+      cmd.recognised_options.map(&:switches).flatten.must_equal ['--ext', '-h', '--help']
     end
   end
 

--- a/test/unit/help/builder_test.rb
+++ b/test/unit/help/builder_test.rb
@@ -69,4 +69,26 @@ describe HammerCLI::Help::Builder do
       help.string.strip.must_equal expected_output
     end
   end
+
+  describe 'option family' do
+    let(:family) { Class.new(HammerCLI::Options::OptionFamily) }
+
+    it 'prints option families' do
+      fm1 = family.new
+      fm1.parent(['--option-zzz'], 'OPT', 'Some description')
+      fm1.child(['--option-aaa'], 'OPT', 'Some description')
+      fm2 = family.new
+      fm2.parent(['--option-bbb'], 'OPT', 'Some description')
+      fm2.child(['--option-yyy'], 'OPT', 'Some description')
+
+      options = fm1.all + fm2.all
+      help.add_list('Options', options)
+
+      help.string.strip.must_equal [
+        'Options:',
+        ' --option[-yyy|-bbb]           Some description',
+        ' --option[-aaa|-zzz]           Some description',
+      ].join("\n")
+    end
+  end
 end

--- a/test/unit/options/option_family_test.rb
+++ b/test/unit/options/option_family_test.rb
@@ -1,0 +1,48 @@
+require_relative '../test_helper'
+
+describe HammerCLI::Options::OptionFamily do
+  let(:family) do
+    HammerCLI::Options::OptionFamily.new(
+      deprecated: { '--test-one' => 'Use --test-two instead' }
+    )
+  end
+  let(:first_option) { HammerCLI::Apipie::OptionDefinition.new("--test-one", '', '') }
+  let(:second_option) { HammerCLI::Apipie::OptionDefinition.new("--test-two", '', '') }
+  let(:third_option) { HammerCLI::Apipie::OptionDefinition.new("--test-three", '', '') }
+  let(:full_family) do
+    family.parent('--test-one', '', 'Test').family.child('--test-two', '', '').family
+  end
+
+  describe 'switch' do
+    it 'returns nil if family is empty' do
+      family.switch.must_be_nil
+    end
+
+    it 'returns parent switch if family has no children' do
+      family.parent('--test-one', '', '')
+      family.switch.must_equal '--test-one'
+    end
+
+    it 'returns switch based on members' do
+      full_family.switch.must_equal '--test[-two|-one]'
+    end
+  end
+
+  describe 'description' do
+    it 'returns parent description if nothing passed to initializer' do
+      full_family.description.must_equal full_family.head.help[1]
+    end
+
+    it 'returns description with deprecation message' do
+      full_family.description.must_equal 'Test (--test-one is deprecated: Use --test-two instead)'
+    end
+  end
+
+  describe 'adopt' do
+    it 'appends an option to children' do
+      full_family.adopt(third_option)
+      full_family.children.size.must_equal 2
+      third_option.family.must_equal full_family
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a way to squeeze options in help output by grouping the options in 'families'.

TODO:
  - [x] - Docs
  - [x] - Tests


Example (for better examples see https://github.com/theforeman/hammer-cli-foreman/pull/489):

```ruby
class MyCommand
  option_family(description: 'Desc for the main switch') do
    parent '--item-id', '', 'Item desc 1'
    child '--item', '', 'Item desc 2'
  end
end

# > hammer -h
# ...
# Options:
#   --item[-id]            Desc for the main switch
# ...
# > hammer full-help
# ...
# Options:
#   --item                   Item desc 2
#   --item-id                Item desc 1
# ... 
```
