### PR TITLE
Fixes #29413 - Add fuzzy subcommand matching

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -454,6 +454,31 @@ Options:
     -h, --help                    print help
 ```
 
+#### Aliasing subcommands
+
+Commands can have two or more names, e.g. aliases. To support such functionality
+simple name addition could be used via `command_name` or `command_names` method:
+```ruby
+module HammerCLIHello
+
+  class SayCommand < HammerCLI::AbstractCommand
+
+    class GreetingsCommand < HammerCLI::AbstractCommand
+      command_name 'hello'
+      command_name 'hi'
+      # or use can use other method:
+      command_names 'hello', 'hi'
+
+      desc 'Say Hello World!'
+      # ...
+    end
+
+    autoload_subcommands
+  end
+
+  HammerCLI::MainCommand.subcommand 'say', "Say something", HammerCLIHello::SayCommand
+end
+```
 
 ### Conflicting subcommands
 It can happen that two different plugins define subcommands with the same name by accident.

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -303,8 +303,17 @@ module HammerCLI
     end
 
     def self.command_name(name=nil)
-      @name = name if name
-      @name || (superclass.respond_to?(:command_name) ? superclass.command_name : nil)
+      if @names && name
+        @names << name if !@names.include?(name)
+      else
+        @names = [name] if name
+      end
+      @names || (superclass.respond_to?(:command_names) ? superclass.command_names : nil)
+    end
+
+    def self.command_names(*names)
+      @names = names unless names.empty?
+      @names || (superclass.respond_to?(:command_names) ? superclass.command_names : nil)
     end
 
     def self.warning(message = nil)

--- a/lib/hammer_cli/exception_handler.rb
+++ b/lib/hammer_cli/exception_handler.rb
@@ -69,7 +69,7 @@ module HammerCLI
 
     def handle_usage_exception(e)
       print_error (_("Error: %{message}") + "\n\n" +
-                   _("See: '%{path} --help'.")) % {:message => e.message, :path => e.command.invocation_path}
+                   _("See: '%{path} --help'.")) % { message: e.message, path: HammerCLI.expand_invocation_path(e.command.invocation_path) }
       log_full_error e
       HammerCLI::EX_USAGE
     end

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -14,7 +14,7 @@ module HammerCLI
       def add_usage(invocation_path, usage_descriptions)
         heading(Clamp.message(:usage_heading))
         usage_descriptions.each do |usage|
-          puts "    #{invocation_path} #{usage}".rstrip
+          puts "    #{HammerCLI.expand_invocation_path(invocation_path)} #{usage}".rstrip
         end
       end
 
@@ -60,6 +60,25 @@ module HammerCLI
         label = "#{label}:"
         label = HighLine.color(label, :bold) if @richtext
         puts label
+      end
+
+      private
+
+      def expand_invocation_path(path)
+        bits = path.split(' ')
+        parent_command = HammerCLI::MainCommand
+        new_path = (bits[1..-1] || []).each_with_object([]) do |bit, names|
+          subcommand = parent_command.find_subcommand(bit)
+          next if subcommand.nil?
+
+          names << if subcommand.names.size > 1
+                     "<#{subcommand.names.join('|')}>"
+                   else
+                     subcommand.names.first
+                   end
+          parent_command = subcommand.subcommand_class
+        end
+        new_path.unshift(bits.first).join(' ')
       end
     end
   end

--- a/lib/hammer_cli/testing/command_assertions.rb
+++ b/lib/hammer_cli/testing/command_assertions.rb
@@ -71,13 +71,13 @@ module HammerCLI
         if heading.nil?
           ["Error: #{message}",
            "",
-           "See: '#{command} --help'.",
+           "See: '#{HammerCLI.expand_invocation_path(command)} --help'.",
            ""].join("\n")
         else
           ["#{heading}:",
            "  Error: #{message}",
            "  ",
-           "  See: '#{command} --help'.",
+           "  See: '#{HammerCLI.expand_invocation_path(command)} --help'.",
            ""].join("\n")
         end
       end

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -116,4 +116,21 @@ module HammerCLI
 
     array.insert(idx, *new_items)
   end
+
+  def self.expand_invocation_path(path)
+    bits = path.split(' ')
+    parent_command = HammerCLI::MainCommand
+    new_path = (bits[1..-1] || []).each_with_object([]) do |bit, names|
+      subcommand = parent_command.find_subcommand(bit)
+      next if subcommand.nil?
+
+      names << if subcommand.names.size > 1
+                 "<#{subcommand.names.join('|')}>"
+               else
+                 subcommand.names.first
+               end
+      parent_command = subcommand.subcommand_class
+    end
+    new_path.unshift(bits.first).join(' ')
+  end
 end

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -262,6 +262,27 @@ describe HammerCLI::AbstractCommand do
       end
 
     end
+
+    describe 'find_subcommand' do
+      it 'should find by full name' do
+        main_cmd.find_subcommand('some_command').wont_be_nil
+      end
+
+      it 'should find by partial name' do
+        main_cmd.find_subcommand('some_').wont_be_nil
+      end
+
+      it 'should not find by wrong name' do
+        main_cmd.find_subcommand('not_existing').must_be_nil
+      end
+
+      it 'should raise if more than one were found' do
+        main_cmd.subcommand('pong', 'description', Subcommand2)
+        proc do
+          main_cmd.find_subcommand('p')
+        end.must_raise HammerCLI::CommandConflict
+      end
+    end
   end
 
   describe "options" do
@@ -413,7 +434,7 @@ describe HammerCLI::AbstractCommand do
     class CmdName2 < CmdName1
     end
 
-    CmdName2.command_name.must_equal 'cmd'
+    CmdName2.command_name.must_equal ['cmd']
   end
 
   it "should inherit output definition" do
@@ -525,7 +546,7 @@ describe HammerCLI::AbstractCommand do
       opt = cmd.find_option('--flag')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
       cmd.output_definition.empty?.must_equal false
-      cmd.new({}).help.must_match(/.*text.*/)
+      cmd.new('', {}).help.must_match(/.*text.*/)
     end
 
     it 'should store more than one extension' do

--- a/test/unit/command_extensions_test.rb
+++ b/test/unit/command_extensions_test.rb
@@ -70,49 +70,49 @@ describe HammerCLI::CommandExtensions do
 
     it 'should extend help only' do
       cmd.extend_with(CmdExtensions.new(only: :help))
-      cmd.new({}).help.must_match(/.*Section.*/)
-      cmd.new({}).help.must_match(/.*text.*/)
+      cmd.new('', {}).help.must_match(/.*Section.*/)
+      cmd.new('', {}).help.must_match(/.*text.*/)
     end
 
     it 'should extend params only' do
       cmd.extend_with(CmdExtensions.new(only: :request_params))
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal({})
-      cmd.new({}).extended_request[2].must_equal({})
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal({})
+      cmd.new('', {}).extended_request[2].must_equal({})
     end
 
     it 'should extend headers only' do
       cmd.extend_with(CmdExtensions.new(only: :request_headers))
-      cmd.new({}).extended_request[0].must_equal({})
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal({})
+      cmd.new('', {}).extended_request[0].must_equal({})
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal({})
     end
 
     it 'should extend options only' do
       cmd.extend_with(CmdExtensions.new(only: :request_options))
-      cmd.new({}).extended_request[0].must_equal({})
-      cmd.new({}).extended_request[1].must_equal({})
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal({})
+      cmd.new('', {}).extended_request[1].must_equal({})
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend params and options and headers' do
       cmd.extend_with(CmdExtensions.new(only: :request))
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend data only' do
       cmd.extend_with(CmdExtensions.new(only: :data))
-      cmd.new({}).help.wont_match(/.*Section.*/)
-      cmd.new({}).help.wont_match(/.*text.*/)
+      cmd.new('', {}).help.wont_match(/.*Section.*/)
+      cmd.new('', {}).help.wont_match(/.*text.*/)
       cmd.output_definition.empty?.must_equal true
       opt = cmd.find_option('--ext')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal false
-      cmd.new({}).extended_request[0].must_equal({})
-      cmd.new({}).extended_request[1].must_equal({})
-      cmd.new({}).extended_request[2].must_equal({})
-      cmd.new({}).extended_data({}).must_equal('key' => 'value')
+      cmd.new('', {}).extended_request[0].must_equal({})
+      cmd.new('', {}).extended_request[1].must_equal({})
+      cmd.new('', {}).extended_request[2].must_equal({})
+      cmd.new('', {}).extended_data({}).must_equal('key' => 'value')
     end
 
     it 'should extend option family only' do
@@ -128,9 +128,9 @@ describe HammerCLI::CommandExtensions do
       opt = cmd.find_option('--ext')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal false
       cmd.output_definition.empty?.must_equal false
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend all except output' do
@@ -138,62 +138,62 @@ describe HammerCLI::CommandExtensions do
       cmd.output_definition.empty?.must_equal true
       opt = cmd.find_option('--ext')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend all except help' do
       cmd.extend_with(CmdExtensions.new(except: :help))
-      cmd.new({}).help.wont_match(/.*Section.*/)
-      cmd.new({}).help.wont_match(/.*text.*/)
+      cmd.new('', {}).help.wont_match(/.*Section.*/)
+      cmd.new('', {}).help.wont_match(/.*text.*/)
       cmd.output_definition.empty?.must_equal false
       opt = cmd.find_option('--ext')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend all except params' do
       cmd.extend_with(CmdExtensions.new(except: :request_params))
-      cmd.new({}).extended_request[0].must_equal({})
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal({})
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend all except headers' do
       cmd.extend_with(CmdExtensions.new(except: :request_headers))
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal({})
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal({})
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
     end
 
     it 'should extend all except options' do
       cmd.extend_with(CmdExtensions.new(except: :request_options))
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal({})
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal({})
     end
 
     it 'should extend all except params and options and headers' do
       cmd.extend_with(CmdExtensions.new(except: :request))
-      cmd.new({}).extended_request[0].must_equal({})
-      cmd.new({}).extended_request[1].must_equal({})
-      cmd.new({}).extended_request[2].must_equal({})
+      cmd.new('', {}).extended_request[0].must_equal({})
+      cmd.new('', {}).extended_request[1].must_equal({})
+      cmd.new('', {}).extended_request[2].must_equal({})
     end
 
     it 'should extend all except data' do
       cmd.extend_with(CmdExtensions.new(except: :data))
-      cmd.new({}).help.must_match(/.*Section.*/)
-      cmd.new({}).help.must_match(/.*text.*/)
+      cmd.new('', {}).help.must_match(/.*Section.*/)
+      cmd.new('', {}).help.must_match(/.*text.*/)
       cmd.output_definition.empty?.must_equal false
       opt = cmd.find_option('--ext')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
-      cmd.new({}).extended_request[0].must_equal(thin: true)
-      cmd.new({}).extended_request[1].must_equal(ssl: true)
-      cmd.new({}).extended_request[2].must_equal(with_authentication: true)
-      cmd.new({}).extended_data({}).must_equal({})
+      cmd.new('', {}).extended_request[0].must_equal(thin: true)
+      cmd.new('', {}).extended_request[1].must_equal(ssl: true)
+      cmd.new('', {}).extended_request[2].must_equal(with_authentication: true)
+      cmd.new('', {}).extended_data({}).must_equal({})
     end
 
     it 'should extend all except option family' do


### PR DESCRIPTION
Adds fuzzy (prefix) subcommand matching as in https://github.com/tstrachota/hammer-cli-experimental.

Allows to use 'reduced' hammer commands, for example:
 - `hammer org l` instead of `hammer organization list`
 - `hammer ro s --id 1` instead of `hammer role show --id 1`
 - `hammer li l` instead of `hammer lifecycle-environment list`

If there is anthoer subcommand that starts with the same prefix, the help error is shown, e.g.:
```
> hammer host i
Error: Found more than one command.

Did you mean one of these?
	index
	info
``` 

Also adds possibility to use aliases for commands, for example:
 - `hammer host show --id 1` instead of `hammer host info --id 1`
 - `hammer host index` instead of `hammer host list`

PR that adds aliases for info/list/delete commands: https://github.com/theforeman/hammer-cli-foreman/pull/512