### PR TITLE
Fixes #30666 - add details to Installation from source doc

### DIFF
--- a/doc/installation_source.md
+++ b/doc/installation_source.md
@@ -8,6 +8,7 @@ Clone and install CLI core
 ```bash
 $ git clone https://github.com/theforeman/hammer-cli.git
 $ cd hammer-cli
+$ bundle install
 $ rake install
 $ cd ..
 ```
@@ -17,6 +18,7 @@ clone plugin with foreman commands
 ```bash
 $ git clone https://github.com/theforeman/hammer-cli-foreman.git
 $ cd hammer-cli-foreman
+$ bundle install
 $ rake install
 $ cd ..
 ```
@@ -25,7 +27,8 @@ and optionally other plugins.
 
 
 #### Step 2: enable and configure the plugins
-You'll have to copy configuration files to proper locations manually.
-Please check our [configuration instructions](installation.md#configuration)
+- Add the plugin as a gem to `Gemfile.local.rb`
+- Copy the configuration files to proper locations manually,
+please check our [configuration instructions](installation.md#configuration)
 and see how to proceed.
 


### PR DESCRIPTION
Installation from source doc should include `bundle install` and explain that to add a plugin you should add it as a gem as well as add config files