### PR TITLE
Fixes #30996 - Better family assignment for options

### DIFF
--- a/lib/hammer_cli/options/option_family.rb
+++ b/lib/hammer_cli/options/option_family.rb
@@ -5,7 +5,7 @@ module HammerCLI
     class OptionFamily
       attr_reader :children
 
-      IDS_REGEX = /\s?([Ii][Dd][s]?)\W|([Ii][Dd][s]?\Z)/
+      IDS_REGEX = /(\A[Ii][Dd][s]?)|\s([Ii][Dd][s]?)\W|([Ii][Dd][s]?\Z)/
 
       def initialize(options = {})
         @all = []
@@ -13,24 +13,30 @@ module HammerCLI
         @options = options
         @creator = options[:creator] || Class.new(HammerCLI::Apipie::Command)
         @prefix = options[:prefix]
-        @description = options[:description]
         @root = options[:root] || options[:aliased_resource] || options[:referenced_resource]
       end
 
       def description
         types = all.map(&:type).map { |s| s.split('_').last.to_s }
-                   .map(&:capitalize).join('/')
-        @description ||= @parent.help[1].gsub(IDS_REGEX) { |w| w.gsub(/\w+/, types) }
+                   .map(&:downcase).join('/')
+        parent_desc = @parent.help[1].gsub(IDS_REGEX) { |w| w.gsub(/\w+/, types) }
+        desc = parent_desc.strip.empty? ? @options[:description] : parent_desc
         if @options[:deprecation].class <= String
-          format_deprecation_msg(@description, _('Deprecated: %{deprecated_msg}') % { deprecated_msg: @options[:deprecation] })
+          format_deprecation_msg(desc, _('Deprecated: %{deprecated_msg}') % { deprecated_msg: @options[:deprecation] })
         elsif @options[:deprecation].class <= Hash
           full_msg = @options[:deprecation].map do |flag, msg|
             _('%{flag} is deprecated: %{deprecated_msg}') % { flag: flag, deprecated_msg: msg }
           end.join(', ')
-          format_deprecation_msg(@description, full_msg)
+          format_deprecation_msg(desc, full_msg)
         else
-          @description
+          desc
         end
+      end
+
+      def formats
+        return [@options[:format].class] if @options[:format]
+
+        all.map(&:value_formatter).map(&:class).uniq
       end
 
       def switch
@@ -67,6 +73,9 @@ module HammerCLI
       end
 
       def adopt(child)
+        raise ArgumentError, 'Parent cannot be a child within the same family' if child == @parent
+        raise ArgumentError, 'Child is already in the family' if @children.include?(child)
+
         child.family = self
         @children << child
       end
@@ -103,9 +112,7 @@ module HammerCLI
         max_len.downto(0) do |curr_len|
           0.upto(max_len - curr_len) do |start|
             root = shortest[start, curr_len]
-            if switches.all? { |switch| switch.include?(root) }
-              return root[2..-1].chomp('-')
-            end
+            return root[2..-1].chomp('-') if switches.all? { |switch| switch.include?(root) }
           end
         end
       end


### PR DESCRIPTION
Now more options are being squeezed properly. Although not all of them if you install more plugins, but after some digging it seems that should be solved in those plugins.

The issue mentions more options than this patch will fix, but as you may notice they are related mostly to hammer-cli-katello and hammer-cli-foreman-discovery plugins. Those options I'll fix in the separate PRs to each of the plugins.

Currently this patch affects the following commands:
 -  user-group update: `--id` option fixed
 -  organization CRUD: `--organization-label` option returned
 
 For easier check of `--help` or `full-help` output differences you can use trick:
 Swap `!` here: https://github.com/theforeman/hammer-cli/blob/93056110a592403623bf72368c7ea98ab85e5a81/lib/hammer_cli/help/builder.rb#L38 and https://github.com/theforeman/hammer-cli/blob/93056110a592403623bf72368c7ea98ab85e5a81/lib/hammer_cli/help/builder.rb#L40