### PR TITLE
Fixes #31563 - Right usage in help output for aliases

### DIFF
--- a/lib/hammer_cli/shell.rb
+++ b/lib/hammer_cli/shell.rb
@@ -97,7 +97,7 @@ module HammerCLI
           history.push(line)
 
           line = HammerCLI::CompleterLine.new(line)
-          ShellMainCommand.run('', line, context) unless line.empty?
+          ShellMainCommand.run('hammer', line, context) unless line.empty?
         end
       rescue Interrupt; end
 

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -121,7 +121,7 @@ module HammerCLI
     bits = path.split(' ')
     parent_command = HammerCLI::MainCommand
     new_path = (bits[1..-1] || []).each_with_object([]) do |bit, names|
-      subcommand = parent_command.find_subcommand(bit, fuzzy: false)
+      subcommand = parent_command.find_subcommand(bit)
       next if subcommand.nil?
 
       names << if subcommand.names.size > 1


### PR DESCRIPTION
This patch fixes an issue that appears if someone tries to use a command in "fuzzy" mode to see its help: the output doesn't contain subcommand names.

To test this try to run e.g. `hammer arch l` or similar (not using full names) before and after this patch. Also should work in hammer shell.