### PR TITLE
Fixes #32444 - Force capitalized field names in help

### DIFF
--- a/lib/hammer_cli/output/definition.rb
+++ b/lib/hammer_cli/output/definition.rb
@@ -73,7 +73,7 @@ module HammerCLI::Output
 
         data << sets.each_with_object({}) do |set, res|
           mark = field.sets.include?(set) ? 'x' : ''
-          value = set == sets.first ? field.full_label : mark
+          value = set == sets.first ? field.full_label.capitalize : mark
           res.update(set => value)
         end
       end

--- a/test/unit/output/definition_test.rb
+++ b/test/unit/output/definition_test.rb
@@ -269,9 +269,9 @@ describe HammerCLI::Output::Definition do
       sets_table = "---------|-----|---------|----\n" \
                    "FIELDS   | ALL | DEFAULT | SET\n" \
                    "---------|-----|---------|----\n" \
-                   "newfield | x   | x       |    \n" \
-                   "cf/abc   |     |         | x  \n" \
-                   "cf/bca   |     |         | x  \n" \
+                   "Newfield | x   | x       |    \n" \
+                   "Cf/abc   |     |         | x  \n" \
+                   "Cf/bca   |     |         | x  \n" \
                    "---------|-----|---------|----\n"
 
       definition.sets_table.must_equal sets_table


### PR DESCRIPTION
Apparently it's confusing for users if field names are shown differently. This fix forces field names in sets help output to be capitalized.