### PR TITLE
Revert "Fixes #29093 - change from superficial copy to deep copy of fields"

### DIFF
--- a/lib/hammer_cli/output/field_filter.rb
+++ b/lib/hammer_cli/output/field_filter.rb
@@ -11,7 +11,7 @@ module HammerCLI::Output
 
     def fields=(fields)
       @fields = fields || []
-      @filtered_fields = Marshal.load(Marshal.dump(@fields))
+      @filtered_fields = @fields.dup
     end
 
     def filter_by_classes(classes = nil)


### PR DESCRIPTION
Reverts theforeman/hammer-cli#345

Since some tests are being broken accross multiple plugins I guess we can revert the changes until we figure out how to fix the tests or fix the issue differently.