### PR TITLE
Fixes #32783 - Change option details section and more

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -190,6 +190,21 @@ To define an option family, use the following DSL:
   end
 ```
 
+You can also add additional options for automatically built ones:
+```ruby
+  # If --resource-id option comes from the API params and you want to add options
+  # with searchables such as --resource-name, --resource-label
+  option_family(associate: 'resource') do
+    child '--resource-name', 'RESOURCE', _('Resource desc'), attribute_name: :option_resource_name
+    child '--resource-label', 'RESOURCE', _('Resource desc'), attribute_name: :option_resource_label
+  end
+  # $ hammer command --help:
+  # ...
+  #  Options:
+  #    --resource[-id|-name|-label]               Resource desc
+  # ...
+```
+
 ##### Example
 
 ```ruby

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -25,6 +25,18 @@ module HammerCLI
     class << self
       attr_accessor :validation_blocks
 
+      def family_registry
+        @family_registry ||= HammerCLI::Options::OptionFamilyRegistry.new
+      end
+
+      def option_families
+        ancestors.inject([]) do |registry, ancestor|
+          next registry unless ancestor <= HammerCLI::AbstractCommand
+
+          registry + ancestor.family_registry
+        end
+      end
+
       def help_extension_blocks
         @help_extension_blocks ||= []
       end
@@ -43,23 +55,35 @@ module HammerCLI
         extensions
       end
 
-      def extend_options_help(option)
+      def add_option_schema(option)
         extend_help do |h|
+          option_details = h.find_item(:s_option_details)
           begin
-            h.find_item(:s_option_details)
+            option_details.definition.find_item(:t_schema_help)
           rescue ArgumentError
-            option_details = HammerCLI::Help::Section.new(_('Option details'), nil, id: :s_option_details, richtext: true)
             option_details.definition << HammerCLI::Help::Text.new(
               _('Following parameters accept format defined by its schema ' \
-                '(bold are required; <> contain acceptable type; [] contain acceptable value):')
+                '(bold are required; <> contains acceptable type; [] contains acceptable value):'),
+              id: :t_schema_help
             )
-            h.definition.unshift(option_details)
-          ensure
-            h.find_item(:s_option_details).definition << HammerCLI::Help::List.new([
-              [option.switches.last, option.value_formatter.schema.description]
-            ])
           end
+          option_details.definition << HammerCLI::Help::List.new([
+            [option.switches.last, option.value_formatter.schema.description]
+          ])
         end
+      end
+
+      def add_option_details_section(help)
+        option_details = HammerCLI::Help::Section.new(_('Option details'), nil, id: :s_option_details, richtext: true)
+        option_details.definition << HammerCLI::Help::Text.new(
+          _('Here you can find option types and the value an option can accept:')
+        )
+        type_list = HammerCLI::Options::Normalizers.available.each_with_object([]) do |n, l|
+          l << [n.completion_type.to_s.upcase, n.common_description]
+        end.uniq(&:first).sort
+
+        option_details.definition << HammerCLI::Help::List.new(type_list)
+        help.definition.unshift(option_details)
       end
 
       def add_sets_help(help)
@@ -138,6 +162,7 @@ module HammerCLI
       super(invocation_path, builder)
       help_extension = HammerCLI::Help::TextBuilder.new(builder.richtext)
       fields_switch = HammerCLI::Options::Predefined::OPTIONS[:fields].first[0]
+      add_option_details_section(help_extension) if recognised_options.size > 1
       add_sets_help(help_extension) if find_option(fields_switch)
       unless help_extension_blocks.empty?
         help_extension_blocks.each do |extension_block|
@@ -194,18 +219,29 @@ module HammerCLI
       @option_builder
     end
 
-    def self.build_options(builder_params={})
-      builder_params = yield(builder_params) if block_given?
-
-      option_builder.build(builder_params).each do |option|
-        # skip switches that are already defined
-        next if option.nil? || option.switches.any? { |s| find_option(s) }
-
-        adjust_family(option) if option.respond_to?(:family)
+    def self.option(switches, type, description, opts = {}, &block)
+      option = HammerCLI::Options::OptionDefinition.new(switches, type, description, opts).tap do |option|
         declared_options << option
         block ||= option.default_conversion_block
         define_accessors_for(option, &block)
-        extend_options_help(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
+        add_option_schema(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
+        completion_type_for(option, opts)
+      end
+      option
+    end
+
+    def self.build_options(builder_params={})
+      builder_params = yield(builder_params) if block_given?
+      builder_params[:command] = self
+
+      option_builder.build(builder_params).each do |option|
+        # skip switches that are already defined
+        next if option.nil? || option.family || option.switches.any? { |s| find_option(s) }
+
+        declared_options << option
+        block ||= option.default_conversion_block
+        define_accessors_for(option, &block)
+        add_option_schema(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
         completion_type_for(option)
       end
     end
@@ -237,8 +273,14 @@ module HammerCLI
 
     def self.option_family(options = {}, &block)
       options[:creator] ||= self
-      family = HammerCLI::Options::OptionFamily.new(options)
-      family.instance_eval(&block)
+      family = if options[:associate]
+                 option_families.find { |f| f.root.to_s == options[:associate].to_s }
+               else
+                 HammerCLI::Options::OptionFamily.new(options)
+               end
+      return family.instance_eval(&block) if family
+
+      logger('Option Family').debug "No family found for #{options[:associate]}, skipping"
     end
 
     def self.find_options(switch_filter, other_filters={})
@@ -339,17 +381,6 @@ module HammerCLI
       end
     end
 
-    def self.option(switches, type, description, opts = {}, &block)
-      option = HammerCLI::Options::OptionDefinition.new(switches, type, description, opts).tap do |option|
-        declared_options << option
-        block ||= option.default_conversion_block
-        define_accessors_for(option, &block)
-        completion_type_for(option, opts)
-      end
-      extend_options_help(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
-      option
-    end
-
     def all_options
       option_collector.all_options
     end
@@ -411,32 +442,6 @@ module HammerCLI
     end
 
     private
-
-    def self.adjust_family(option)
-      # Collect options that should share the same family
-      # If those options have family, adopt the current one
-      # Else adopt those options to the family of the current option
-      # NOTE: this shouldn't rewrite any options,
-      # although options from similar family could be adopted (appended)
-      options = find_options(
-        aliased_resource: option.aliased_resource.to_s
-      ).select { |o| o.family.nil? || o.family.formats.include?(option.value_formatter.class) }.group_by do |o|
-        next :to_skip if option.family.children.include?(o)
-        next :to_adopt if o.family.nil? || o.family.head.nil?
-        next :to_skip if o.family.children.include?(option)
-        # If both family heads handle the same switch
-        # then `option` is probably from similar family and can be adopted
-        next :adopt_by if option.family.head.nil? || o.family.head.handles?(option.family.head.long_switch)
-
-        :to_skip
-      end
-      options[:to_adopt]&.each do |child|
-        option.family&.adopt(child)
-      end
-      options[:adopt_by]&.map(&:family)&.uniq&.each do |family|
-        family.adopt(option)
-      end
-    end
 
     def self.inherited_output_definition
       od = nil

--- a/lib/hammer_cli/apipie/command.rb
+++ b/lib/hammer_cli/apipie/command.rb
@@ -86,9 +86,9 @@ module HammerCLI::Apipie
         declared_options << option
         block ||= option.default_conversion_block
         define_accessors_for(option, &block)
+        add_option_schema(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
         completion_type_for(option, opts)
       end
-      extend_options_help(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
       option
     end
 

--- a/lib/hammer_cli/apipie/option_definition.rb
+++ b/lib/hammer_cli/apipie/option_definition.rb
@@ -2,22 +2,15 @@ require File.join(File.dirname(__FILE__), 'options')
 
 module HammerCLI::Apipie
   class OptionDefinition < HammerCLI::Options::OptionDefinition
-    attr_accessor :referenced_resource, :aliased_resource, :family
+    attr_accessor :referenced_resource, :aliased_resource
 
     def initialize(switches, type, description, options = {})
       @referenced_resource = options[:referenced_resource].to_s if options[:referenced_resource]
       @aliased_resource = options[:aliased_resource].to_s if options[:aliased_resource]
-      @family = options[:family]
       super
       # Apipie currently sends descriptions as escaped HTML once this is changed this should be removed.
       # See #15198 on Redmine.
       @description = CGI::unescapeHTML(description)
-    end
-
-    def child?
-      return unless @family
-
-      @family.children.include?(self)
     end
   end
 end

--- a/lib/hammer_cli/command_extensions.rb
+++ b/lib/hammer_cli/command_extensions.rb
@@ -87,8 +87,11 @@ module HammerCLI
     end
 
     def self.option_family(options = {}, &block)
-      @option_family_opts = options
-      @option_family_block = block
+      @option_family_extensions ||= []
+      @option_family_extensions << {
+        options: options,
+        block: block
+      }
     end
 
     # Object
@@ -256,11 +259,13 @@ module HammerCLI
     end
 
     def self.extend_option_family(command_class)
-      return if @option_family_block.nil?
+      return if @option_family_extensions.nil?
 
-      @option_family_opts[:creator] = command_class
-      command_class.send(:option_family, @option_family_opts, &@option_family_block)
-      logger.debug("Called option family block for #{command_class}:\n\t#{@option_family_block}")
+      @option_family_extensions.each do |extension|
+        extension[:options][:creator] = command_class
+        command_class.send(:option_family, extension[:options], &extension[:block])
+        logger.debug("Called option family block for #{command_class}:\n\t#{extension[:block]}")
+      end
     end
   end
 end

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -29,7 +29,11 @@ module HammerCLI
 
         label_width = DEFAULT_LABEL_INDENT
         items.each do |item|
-          label = item.help.first
+          label = if !HammerCLI.context[:full_help] && item.respond_to?(:family) && item.family && !item.child?
+                    item.family.help.first
+                  else
+                    item.help.first
+                  end
           label_width = label.size if label.size > label_width
         end
 
@@ -38,10 +42,10 @@ module HammerCLI
             next unless HammerCLI.context[:full_help]
           end
           label, description = if !HammerCLI.context[:full_help] && item.respond_to?(:family) && item.family
-            [item.family.switch, item.family.description || item.help[1]]
-          else
-            item.help
-          end
+                                 item.family.help
+                               else
+                                 item.help
+                               end
           description.gsub(/^(.)/) { Unicode::capitalize($1) }.each_line do |line|
             puts " %-#{label_width}s %s" % [label, line]
             label = ''

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -17,7 +17,7 @@ describe HammerCLI::Apipie::OptionBuilder do
   let(:resource) {api.resource(:documented)}
   let(:action) {resource.action(:index)}
   let(:builder) { HammerCLI::Apipie::OptionBuilder.new(resource, action) }
-  let(:builder_options) { {} }
+  let(:builder_options) { { command: Class.new(HammerCLI::Apipie::Command) } }
   let(:options) { builder.build(builder_options) }
 
   context "with one simple param" do
@@ -51,7 +51,7 @@ describe HammerCLI::Apipie::OptionBuilder do
   context "required options" do
 
     let(:action) {resource.action(:create)}
-    let(:required_options) { builder.build.reject{|opt| !opt.required?} }
+    let(:required_options) { builder.build(builder_options).reject{|opt| !opt.required?} }
 
     it "should set required flag for the required options" do
       required_options.map(&:attribute_name).sort.must_equal [HammerCLI.option_accessor_name("array_param")]
@@ -146,7 +146,12 @@ describe HammerCLI::Apipie::OptionBuilder do
 
   context "aliasing resources" do
     let(:action) {resource.action(:action_with_ids)}
-    let(:builder_options) { {:resource_mapping => {:organization => 'company', 'compute_resource' => :compute_provider}} }
+    let(:builder_options) do
+      {
+        resource_mapping: { organization: 'company', 'compute_resource' => :compute_provider },
+        command: Class.new(HammerCLI::Apipie::Command)
+      }
+    end
 
     it "renames options" do
       # builder_options[:resource_mapping] = {:organization => 'company', 'compute_resource' => :compute_provider}

--- a/test/unit/command_extensions_test.rb
+++ b/test/unit/command_extensions_test.rb
@@ -118,7 +118,7 @@ describe HammerCLI::CommandExtensions do
     it 'should extend option family only' do
       cmd.extend_with(CmdExtensions.new(only: :option_family))
       cmd.output_definition.empty?.must_equal true
-      cmd.recognised_options.map(&:switches).flatten.must_equal ['--test-one', '--test-two', '-h', '--help']
+      cmd.recognised_options.map(&:switches).flatten.must_equal ['-h', '--help', '--test-one', '--test-two']
     end
   end
 

--- a/test/unit/help/builder_test.rb
+++ b/test/unit/help/builder_test.rb
@@ -86,8 +86,8 @@ describe HammerCLI::Help::Builder do
 
       help.string.strip.must_equal [
         'Options:',
-        ' --option[-yyy|-bbb]           Some description',
-        ' --option[-aaa|-zzz]           Some description',
+        ' --option[-yyy|-bbb] VALUE     Some description',
+        ' --option[-aaa|-zzz] VALUE     Some description'
       ].join("\n")
     end
   end


### PR DESCRIPTION
This patch introduces a new section "Option details" with listed
option types and accepted values. Changes the way for automatic
option building making API params to be the main options. Also
deprecation warning will be shown only when a specific option is
actually being used.