### PR TITLE
Fixes #32783 - Extract descs to option details section

### DIFF
--- a/lib/hammer_cli/apipie/command.rb
+++ b/lib/hammer_cli/apipie/command.rb
@@ -86,9 +86,9 @@ module HammerCLI::Apipie
         declared_options << option
         block ||= option.default_conversion_block
         define_accessors_for(option, &block)
+        add_option_schema(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
         completion_type_for(option, opts)
       end
-      extend_options_help(option) if option.value_formatter.is_a?(HammerCLI::Options::Normalizers::ListNested)
       option
     end
 

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -29,7 +29,11 @@ module HammerCLI
 
         label_width = DEFAULT_LABEL_INDENT
         items.each do |item|
-          label = item.help.first
+          label = if !HammerCLI.context[:full_help] && item.respond_to?(:family) && item.family && !item.child?
+                    item.family.help.first
+                  else
+                    item.help.first
+                  end
           label_width = label.size if label.size > label_width
         end
 
@@ -38,10 +42,10 @@ module HammerCLI
             next unless HammerCLI.context[:full_help]
           end
           label, description = if !HammerCLI.context[:full_help] && item.respond_to?(:family) && item.family
-            [item.family.switch, item.family.description || item.help[1]]
-          else
-            item.help
-          end
+                                 item.family.help
+                               else
+                                 item.help
+                               end
           description.gsub(/^(.)/) { Unicode::capitalize($1) }.each_line do |line|
             puts " %-#{label_width}s %s" % [label, line]
             label = ''

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -36,7 +36,9 @@ module HammerCLI
       end
 
       def help_lhs
-        super
+        lhs = switches.join(', ')
+        lhs += " #{completion_type[:type]}".upcase unless flag?
+        lhs
       end
 
       def help_rhs
@@ -140,22 +142,7 @@ module HammerCLI
         return { type: :flag } if @type == :flag
 
         formatter ||= value_formatter
-        completion_type = case formatter
-                          when HammerCLI::Options::Normalizers::Bool,
-                               HammerCLI::Options::Normalizers::Enum
-                            { type: :enum, values: value_formatter.allowed_values }
-                          when HammerCLI::Options::Normalizers::EnumList
-                            { type: :multienum, values: value_formatter.allowed_values }
-                          when HammerCLI::Options::Normalizers::ListNested
-                            { type: :schema, schema: value_formatter.schema.description(richtext: false) }
-                          when HammerCLI::Options::Normalizers::List
-                            { type: :list }
-                          when HammerCLI::Options::Normalizers::KeyValueList
-                            { type: :key_value_list }
-                          when HammerCLI::Options::Normalizers::File
-                            { type: :file }
-                          end
-        completion_type || { type: :value }
+        formatter.completion_type
       end
 
       private

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -308,6 +308,13 @@ describe HammerCLI::AbstractCommand do
       opt = TestOptionCmd.find_option('--fields')
       opt.is_a?(HammerCLI::Options::OptionDefinition).must_equal true
     end
+
+    it 'should add option type and accepted value' do
+      help_str = TestOptionCmd.help('')
+      help_str.must_match(
+        /LIST                Comma separated list of values. Values containing comma should be quoted or escaped with backslash./
+      )
+    end
   end
 
   describe "#options" do

--- a/test/unit/help/builder_test.rb
+++ b/test/unit/help/builder_test.rb
@@ -86,8 +86,8 @@ describe HammerCLI::Help::Builder do
 
       help.string.strip.must_equal [
         'Options:',
-        ' --option[-yyy|-bbb]           Some description',
-        ' --option[-aaa|-zzz]           Some description',
+        ' --option[-yyy|-bbb] VALUE     Some description',
+        ' --option[-aaa|-zzz] VALUE     Some description'
       ].join("\n")
     end
   end


### PR DESCRIPTION
@yifatmakias, I've extracted this part from https://github.com/theforeman/hammer-cli/pull/349 and those changes are needed to only fix the described issue.

For easier review:

1. `Option details` section should be added now only if there more than one default option (`--help`).
2. `Option details` section now contains new entries describing what can be used as a value for an option.
3. Those entries are being generated automatically based on available option `Normalizer`s.