### PR TITLE
Fixes #33810 - Remove a space in hammer's shebang

### DIFF
--- a/bin/hammer
+++ b/bin/hammer
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'clamp'


### PR DESCRIPTION
This space confuses Debian packaging on Ubuntu 20.04 and causes it to not be replaced. The end result is that it may end up using the wrong Ruby.