### PR TITLE
Fixes #28283 - Autodetect if apidoc cache needs reload

### DIFF
--- a/config/cli_config.template.yml
+++ b/config/cli_config.template.yml
@@ -47,6 +47,10 @@
 # Location of cache for bash completion
 :completion_cache_file: '~/.cache/hammer_completion.json'
 
+# Location of cache for hammer plugin versions
+# Needed to automatically detect if hammer needs to reload API documentation
+:checksum_cache_file: '~/.cache/hammer_modules_checksum'
+
 # SSL auth options
 #:ssl:
   # Path to a CA file in PEM format, mutually exclusive with :ssl_ca_path:

--- a/lib/hammer_cli/apipie/api_connection.rb
+++ b/lib/hammer_cli/apipie/api_connection.rb
@@ -8,7 +8,7 @@ module HammerCLI::Apipie
     def initialize(params, options = {})
       @logger = options[:logger]
       @api = ApipieBindings::API.new(params, HammerCLI::SSLOptions.new.get_options(params[:uri]))
-      if options[:reload_cache]
+      if options[:reload_cache] || (options[:use_modules_checksum] && HammerCLI::Modules.changed?)
         @api.clean_cache
         HammerCLI.clear_cache
         unless @logger.nil?

--- a/lib/hammer_cli/settings.rb
+++ b/lib/hammer_cli/settings.rb
@@ -66,8 +66,9 @@ module HammerCLI
 
     def self.default_settings
       {
-        :use_defaults => true,
-        :completion_cache_file => '~/.cache/hammer_completion.json'
+        use_defaults: true,
+        completion_cache_file: '~/.cache/hammer_completion.json',
+        checksum_cache_file: '~/.cache/hammer_modules_checksum'
       }
     end
 

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -67,8 +67,10 @@ module HammerCLI
   end
 
   def self.clear_cache
-    cache_file = File.expand_path(HammerCLI::Settings.get(:completion_cache_file))
-    File.delete(cache_file) if File.exist?(cache_file)
+    %i[checksum_cache_file completion_cache_file].each do |f|
+      cache_file = File.expand_path(HammerCLI::Settings.get(f))
+      File.delete(cache_file) if File.exist?(cache_file)
+    end
   end
 
   def self.interactive?


### PR DESCRIPTION
This is only a base to use in plugins, by default it's off (only a cache file is being created the first time). The usage is quite simple: https://github.com/theforeman/hammer-cli-foreman/pull/594.

This fix adds a new checksum based on installed plugins and their versions. If there was a new plugin installed or an old one was upgraded, then the old cache will be removed and thus a new cache will be downloaded automatically.

The only issue that persists is `hammer command action --help` won't show new options if the server was upgraded and added new params **unless** the corresponding hammer plugin was upgraded as well or `--reload-cache` was called manually or it's a brand new hammer installation. This is due to how `apipie-bindings` receives and uses stored cache. There is an option to force invalidating of the cache each time we run hammer, but it still needs to talk to the server (to load cache's checksum), but I don't find that a good idea since it's quite unnecessary to call server's API to simply show the help output (even if it will be fully updated).

I was thinking about other ways to detect when the autoreloading needs to be done, but since hammer can be installed as a simple gem and on a different machine than the server, there is no other way then to force an API call each time the hammer is being used (even for the help output only).

UPD: **Don't** merge just yet, I found out that it behaives differently in production...