### PR TITLE
Fixes #34724 - Fix hammer shell with pipe as stdin

### DIFF
--- a/lib/hammer_cli/shell.rb
+++ b/lib/hammer_cli/shell.rb
@@ -86,7 +86,7 @@ module HammerCLI
       Readline.completer_word_break_characters = ' ='
       Readline.completion_proc = complete_proc
 
-      stty_save = `stty -g`.chomp
+      stty_save = `stty -g`.chomp if $stdin.tty?
 
       history = ShellHistory.new(Settings.get(:ui, :history_file) || DEFAULT_HISTORY_FILE)
 
@@ -102,7 +102,8 @@ module HammerCLI
       rescue Interrupt; end
 
       puts
-      system('stty', stty_save) # Restore
+      # Restore
+      system('stty', stty_save) if $stdin.tty?
       HammerCLI::EX_OK
     end
 


### PR DESCRIPTION
Hammer shell tries to store terminal properties with `stty -g` and restore
them once it is done. This works rather poorly when the input is not a
tty (a pipe). When run in such a way, hammer complains about a couple of
things, depending on platform, possibly caused by different `stty`
versions.

This should prevent the following errors from showing up:
```
stty: 'standard input': Inappropriate ioctl for device
```
```
stty: invalid argument ‘’
Try 'stty --help' for more information.
```