### PR TITLE
Include Makefile.def in the gem

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -20,7 +20,7 @@ EOF
   locales = Dir['locale/*'].select { |f| File.directory?(f) }
   s.files = Dir['{lib,test,bin,doc,config}/**/*', 'LICENSE', 'README*'] +
     locales.map { |loc| "#{loc}/LC_MESSAGES/hammer-cli.mo" } +
-    ['man/hammer.1.gz']
+    ['locale/Makefile.def', 'man/hammer.1.gz']
 
   s.test_files       = Dir['test/**/*']
   s.extra_rdoc_files = Dir['{doc,config}/**/*', 'README*']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.root Pathname.new(File.dirname(__FILE__) + "../../../")
 require 'minitest/autorun'
 require 'minitest/spec'
 require "minitest-spec-context"
-require "mocha/setup"
+require "mocha/minitest"
 
 require 'hammer_cli'
 require 'hammer_cli/logger'


### PR DESCRIPTION
In 649d103e861852c22fa68710cdb7be67c0c7e266 infrastructure was added to make translation management reusable. Later this was broken in f1b2e8b67bef81f26894f159171da6f7f55a456b when the gemspec was trimmed to only include .mo files. That meant that other Hammer plugins couldn't actually use the infrastructure.

Fixes: f1b2e8b67bef81f26894f159171da6f7f55a456b