### PR TITLE
Fixes #36337 - Update rake and clamp deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 group :test do
-  gem 'rake', '~> 10.1.0'
+  gem 'rake'
   gem 'thor'
   gem 'minitest', '4.7.4'
   gem 'minitest-spec-context'

--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ Rake::TestTask.new do |t|
   t.libs.push "lib"
   t.test_files = Dir.glob('test/**/*_test.rb')
   t.verbose = true
+  t.warning = ENV.key?('RUBY_WARNINGS')
 end
 
 file "man/hammer.1.gz" => "man/hammer.1.asciidoc" do |t|

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -27,7 +27,9 @@ EOF
   s.require_paths = ["lib"]
   s.executables = ['hammer', 'hammer-complete']
 
-  s.add_dependency 'clamp', '>= 1.1', '< 1.2.0'
+  s.required_ruby_version = '>= 2.7'
+
+  s.add_dependency 'clamp', '>= 1.3.1', '< 2.0.0'
   s.add_dependency 'logging'
   s.add_dependency 'unicode-display_width'
   s.add_dependency 'unicode'

--- a/lib/hammer_cli/abstract.rb
+++ b/lib/hammer_cli/abstract.rb
@@ -192,7 +192,7 @@ module HammerCLI
 
     def self.output(definition=nil, &block)
       dsl = HammerCLI::Output::Dsl.new
-      dsl.build &block if block_given?
+      dsl.build(&block) if block_given?
       output_definition.append definition.fields unless definition.nil?
       output_definition.append dsl.fields
     end

--- a/lib/hammer_cli/defaults_commands.rb
+++ b/lib/hammer_cli/defaults_commands.rb
@@ -1,4 +1,3 @@
-require 'hammer_cli'
 require 'yaml'
 module HammerCLI
   class BaseDefaultsProvider

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -14,7 +14,7 @@ module HammerCLI
       def add_usage(invocation_path, usage_descriptions)
         heading(Clamp.message(:usage_heading))
         usage_descriptions.each do |usage|
-          puts "    #{HammerCLI.expand_invocation_path(invocation_path)} #{usage}".rstrip
+          line "    #{HammerCLI.expand_invocation_path(invocation_path)} #{usage}".rstrip
         end
       end
 
@@ -24,7 +24,7 @@ module HammerCLI
         end
         items.reject! {|item| item.respond_to?(:hidden?) && item.hidden?}
 
-        puts
+        line
         heading(heading)
 
         label_width = DEFAULT_LABEL_INDENT
@@ -47,15 +47,15 @@ module HammerCLI
                                  item.help
                                end
           description.gsub(/^(.)/) { Unicode.capitalize(Regexp.last_match(1)) }.wrap.each_line do |line|
-            puts " %-#{label_width}s %s" % [label, line]
+            line " %-#{label_width}s %s" % [label, line]
             label = ''
           end
         end
       end
 
       def add_text(content)
-        puts
-        puts content
+        line
+        line content
       end
 
       protected
@@ -63,7 +63,7 @@ module HammerCLI
       def heading(label)
         label = "#{label}:"
         label = HighLine.color(label, :bold) if @richtext
-        puts label
+        line label
       end
     end
   end

--- a/lib/hammer_cli/logger.rb
+++ b/lib/hammer_cli/logger.rb
@@ -54,7 +54,7 @@ module HammerCLI
       log_dir = File.expand_path(HammerCLI::Settings.get(:log_dir) || DEFAULT_LOG_DIR)
       begin
         FileUtils.mkdir_p(log_dir, :mode => 0750)
-      rescue Errno::EACCES => e
+      rescue Errno::EACCES
         $stderr.puts _("No permissions to create log dir %s.") % log_dir
       end
 
@@ -68,7 +68,7 @@ module HammerCLI
                                                             :size     => (HammerCLI::Settings.get(:log_size) || 1)*1024*1024) # 1MB
         # set owner and group (it's ignored if attribute is nil)
         FileUtils.chown HammerCLI::Settings.get(:log_owner), HammerCLI::Settings.get(:log_group), filename
-      rescue ArgumentError => e
+      rescue ArgumentError
         $stderr.puts _("File %s not writeable, won't log anything to the file!") % filename
       end
 

--- a/lib/hammer_cli/modules.rb
+++ b/lib/hammer_cli/modules.rb
@@ -67,7 +67,7 @@ module HammerCLI
 
     def self.load(name)
       load! name
-    rescue Exception => e
+    rescue Exception
       false
     end
 

--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -298,7 +298,7 @@ module HammerCLI
           json_string = ::File.exist?(::File.expand_path(val)) ? super(val) : val
           ::JSON.parse(json_string)
 
-        rescue ::JSON::ParserError => e
+        rescue ::JSON::ParserError
           raise ArgumentError, _("Unable to parse JSON input.")
         end
 

--- a/lib/hammer_cli/options/validators/dsl.rb
+++ b/lib/hammer_cli/options/validators/dsl.rb
@@ -152,7 +152,7 @@ module HammerCLI
         end
 
         def run(&block)
-          self.instance_eval &block
+          self.instance_eval(&block)
         end
       end
     end

--- a/lib/hammer_cli/output/adapter/csv.rb
+++ b/lib/hammer_cli/output/adapter/csv.rb
@@ -94,7 +94,6 @@ module HammerCLI::Output::Adapter
         @name = nil
         @prefixes = []
         @suffixes = []
-        @data
       end
 
       def append_suffix(suffix)

--- a/lib/hammer_cli/output/dsl.rb
+++ b/lib/hammer_cli/output/dsl.rb
@@ -12,7 +12,7 @@ module HammerCLI::Output
     end
 
     def build(&block)
-      self.instance_eval &block
+      self.instance_eval(&block)
     end
 
     protected

--- a/lib/hammer_cli/output/fields.rb
+++ b/lib/hammer_cli/output/fields.rb
@@ -72,7 +72,7 @@ module Fields
     def initialize(options={}, &block)
       super(options)
       dsl = HammerCLI::Output::Dsl.new
-      dsl.build &block if block_given?
+      dsl.build(&block) if block_given?
       dsl.fields.each { |f| f.parent = self }
       self.output_definition.append dsl.fields
     end

--- a/lib/hammer_cli/output/formatters.rb
+++ b/lib/hammer_cli/output/formatters.rb
@@ -13,7 +13,7 @@ module HammerCLI::Output
 
       def register_formatter(type, *formatters)
         if @_formatters[type].nil?
-          @_formatters[type] = FormatterContainer.new *formatters
+          @_formatters[type] = FormatterContainer.new(*formatters)
         else
           formatters.each { |f| @_formatters[type].add_formatter(f) }
         end

--- a/lib/hammer_cli/output/formatters.rb
+++ b/lib/hammer_cli/output/formatters.rb
@@ -84,8 +84,8 @@ module HammerCLI::Output
         tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
       end
 
-      def format(data, field_params={})
-        c = HighLine.color(data.to_s, @color)
+      def format(data, _={})
+        HighLine.color(data.to_s, @color)
       end
     end
 
@@ -97,7 +97,7 @@ module HammerCLI::Output
         tags.map { |t| HammerCLI::Output::Utils.tag_to_feature(t) }
       end
 
-      def format(string_date, field_params={})
+      def format(string_date, _={})
         t = DateTime.parse(string_date.to_s)
         t.strftime("%Y/%m/%d %H:%M:%S")
       rescue ArgumentError

--- a/lib/hammer_cli/ssloptions.rb
+++ b/lib/hammer_cli/ssloptions.rb
@@ -68,13 +68,13 @@ module HammerCLI
 
     def read_certificate(path)
       OpenSSL::X509::Certificate.new(File.read(path)) unless path.nil?
-    rescue SystemCallError => e
+    rescue SystemCallError
       warn _("Could't read SSL client certificate %s.") % path
     end
 
     def read_key(path)
       OpenSSL::PKey.read(File.read(path)) unless path.nil?
-    rescue SystemCallError => e
+    rescue SystemCallError
       warn _("Could't read SSL client key %s.") % path
     end
   end

--- a/lib/hammer_cli/subcommand.rb
+++ b/lib/hammer_cli/subcommand.rb
@@ -11,6 +11,7 @@ module HammerCLI
         @subcommand_class = subcommand_class
         @hidden = options[:hidden]
         @warning = options[:warning]
+        super(@names, @description, @subcommand_class)
       end
 
       def hidden?

--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -48,18 +48,6 @@ class String
   end
 end
 
-class Hash
-  # for ruby < 2.5.0
-  def transform_keys
-    result = {}
-    each do |key, value|
-      new_key = yield key
-      result[new_key] = value
-    end
-    result
-  end
-end
-
 module HammerCLI
 
   def self.tty?

--- a/test/functional/defaults_test.rb
+++ b/test/functional/defaults_test.rb
@@ -24,7 +24,6 @@ describe 'commands' do
     let(:cmd) { ['defaults', 'list'] }
 
     it 'prints all defaults' do
-      header = 'Parameter,Value'
       default_values = {
         :organization_id => {
           :value => 3,

--- a/test/unit/apipie/command_test.rb
+++ b/test/unit/apipie/command_test.rb
@@ -42,7 +42,7 @@ describe HammerCLI::Apipie::Command do
     let(:cmd_class) { CommandUnsupp.dup }
     let(:cmd) { cmd_class.new("unsupported", ctx) }
     it "should print help for unsupported command" do
-      assert_match /.*Unfortunately the server does not support such operation.*/, cmd.help
+      assert_match(/.*Unfortunately the server does not support such operation.*/, cmd.help)
     end
 
   end

--- a/test/unit/apipie/option_definition_test.rb
+++ b/test/unit/apipie/option_definition_test.rb
@@ -23,7 +23,7 @@ describe HammerCLI::Apipie::OptionDefinition do
 
   end
 
-  let(:opt2) { HammerCLI::Apipie::OptionDefinition.new("--opt2", "OPT2", "&#39;OPT2&#39;", :referenced_resource => @referenced_resource) }
+  let(:opt2) { HammerCLI::Apipie::OptionDefinition.new("--opt2", "OPT2", "&#39;OPT2&#39;") }
 
   describe "Option Description should be converted" do
     it "should be converted" do

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -30,7 +30,7 @@ describe HammerCLI::ExceptionHandler do
   end
 
   it "should handle help request" do
-    output.expects(:print_message).with(cmd.help, {}, verbosity: HammerCLI::V_QUIET)
+    output.expects(:print_message).with(cmd.help, {}, { verbosity: HammerCLI::V_QUIET })
     handler.handle_exception(Clamp::HelpWanted.new(cmd), :heading => heading)
 
   end
@@ -51,8 +51,8 @@ describe HammerCLI::ExceptionHandler do
     ex = RestClient::ResourceNotFound.new
     output.default_adapter = :silent
     handler.handle_exception(ex)
-    assert_match /Using exception handler HammerCLI::ExceptionHandler#handle_not_found/, @log_output.readline.strip
-    assert_match /ERROR  Exception : (Resource )?Not Found/, @log_output.readline.strip
+    assert_match(/Using exception handler HammerCLI::ExceptionHandler#handle_not_found/, @log_output.readline.strip)
+    assert_match(/ERROR  Exception : (Resource )?Not Found/, @log_output.readline.strip)
   end
 
   it "should print default prompts for standard missing arguments" do

--- a/test/unit/history_test.rb
+++ b/test/unit/history_test.rb
@@ -20,13 +20,13 @@ describe HammerCLI::ShellHistory do
   describe "loading old history" do
 
     it "skips loading if the file does not exist" do
-      history = HammerCLI::ShellHistory.new(new_file.path)
+      HammerCLI::ShellHistory.new(new_file.path)
 
       Readline::HISTORY.to_a.must_equal []
     end
 
     it "preseeds readline's history" do
-      history = HammerCLI::ShellHistory.new(history_file.path)
+      HammerCLI::ShellHistory.new(history_file.path)
 
       Readline::HISTORY.to_a.must_equal ["line 1", "line 2"]
     end

--- a/test/unit/logger_test.rb
+++ b/test/unit/logger_test.rb
@@ -4,7 +4,7 @@ require 'tempfile'
 describe Logging::LogEvent do
 
   describe '#initialize_logger' do
-    let (:logger) { Logging::Logger.new(File.open('/dev/null')) }
+    let(:logger) { Logging::Logger.new(File.open('/dev/null')) }
 
     it "prints message to stderr when log dir can't be created" do
         log_dir = "/nonexistant/dir/logs"
@@ -12,7 +12,7 @@ describe Logging::LogEvent do
 
         HammerCLI::Settings.load({:log_dir => log_dir})
 
-        out, err = capture_io do
+        _, err = capture_io do
           HammerCLI::Logger::initialize_logger(logger)
         end
 

--- a/test/unit/options/option_definition_test.rb
+++ b/test/unit/options/option_definition_test.rb
@@ -64,7 +64,7 @@ describe HammerCLI::Options::OptionDefinition do
       cmd = TestDeprecatedOptionCmd.new("", context)
 
       out, err = capture_io { cmd.run(["--another-deprecated=VALUE"]) }
-      err.must_match /Warning: Option --another-deprecated is deprecated. It is going to be removed/
+      err.must_match(/Warning: Option --another-deprecated is deprecated. It is going to be removed/)
       context[:old_option].must_equal "VALUE"
     end
 
@@ -73,7 +73,7 @@ describe HammerCLI::Options::OptionDefinition do
       cmd = TestDeprecatedOptionCmd.new("", context)
 
       out, err = capture_io { cmd.run(["--deprecated=VALUE"]) }
-      err.must_match /Warning: Option --deprecated is deprecated. Use --test-option instead/
+      err.must_match(/Warning: Option --deprecated is deprecated. Use --test-option instead/)
       context[:test_option].must_equal "VALUE"
     end
 

--- a/test/unit/options/option_definition_test.rb
+++ b/test/unit/options/option_definition_test.rb
@@ -63,7 +63,7 @@ describe HammerCLI::Options::OptionDefinition do
       context = {}
       cmd = TestDeprecatedOptionCmd.new("", context)
 
-      out, err = capture_io { cmd.run(["--another-deprecated=VALUE"]) }
+      _, err = capture_io { cmd.run(["--another-deprecated=VALUE"]) }
       err.must_match(/Warning: Option --another-deprecated is deprecated. It is going to be removed/)
       context[:old_option].must_equal "VALUE"
     end
@@ -72,7 +72,7 @@ describe HammerCLI::Options::OptionDefinition do
       context = {}
       cmd = TestDeprecatedOptionCmd.new("", context)
 
-      out, err = capture_io { cmd.run(["--deprecated=VALUE"]) }
+      _, err = capture_io { cmd.run(["--deprecated=VALUE"]) }
       err.must_match(/Warning: Option --deprecated is deprecated. Use --test-option instead/)
       context[:test_option].must_equal "VALUE"
     end

--- a/test/unit/options/sources/saved_defaults_test.rb
+++ b/test/unit/options/sources/saved_defaults_test.rb
@@ -20,10 +20,6 @@ describe HammerCLI::Options::Sources::SavedDefaults do
       @defaults.expects(:get_defaults).with('--test-multi1').returns(:first_value)
 
       current_result = {}
-      expected_result = {
-        :different_attr_name => 1,
-        :multiple_switches_option => :first_value
-      }
 
       @logger.expects(:info).with('Custom default value 1 was used for attribute --test')
       @logger.expects(:info).with('Custom default value first_value was used for attribute --test-multi1')

--- a/test/unit/output/adapter/abstract_test.rb
+++ b/test/unit/output/adapter/abstract_test.rb
@@ -27,7 +27,7 @@ describe HammerCLI::Output::Adapter::Abstract do
   it "should filter formatters with incompatible features" do
 
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [] })
-    adapter = adapter_class.new({}, {:type => [UnknownTestFormatter.new]})
+    adapter_class.new({}, {:type => [UnknownTestFormatter.new]})
   end
 
   it "should keep compatible formatters" do
@@ -35,7 +35,7 @@ describe HammerCLI::Output::Adapter::Abstract do
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [formatter] })
     # set :unknown tag to abstract
     adapter_class.any_instance.stubs(:features).returns([:unknown])
-    adapter = adapter_class.new({}, {:type => [formatter]})
+    adapter_class.new({}, {:type => [formatter]})
   end
 
   it "should put serializers first" do
@@ -46,7 +46,7 @@ describe HammerCLI::Output::Adapter::Abstract do
     HammerCLI::Output::Formatters::FormatterLibrary.expects(:new).with({ :type => [formatter2, formatter1] })
     # set :unknown tag to abstract
     adapter_class.any_instance.stubs(:features).returns([:serialized])
-    adapter = adapter_class.new({}, {:type => [formatter1, formatter2]})
+    adapter_class.new({}, {:type => [formatter1, formatter2]})
   end
 
 

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -59,14 +59,14 @@ describe HammerCLI::Output::Adapter::CSValues do
       }]}
 
       it "should ommit column of type Id by default" do
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.wont_match(/.*Id.*/)
         out.wont_match(/.*2000,.*/)
       end
 
       it "should print column of type Id when --show-ids is set" do
         adapter = HammerCLI::Output::Adapter::CSValues.new( { :show_ids => true } )
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*Id.*/)
       end
     end
@@ -75,12 +75,12 @@ describe HammerCLI::Output::Adapter::CSValues do
       let(:empty_data) { HammerCLI::Output::RecordCollection.new [] }
 
       it "should print headers by default" do
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*Name.*/)
       end
 
       it "should print headers by default even if there is no data" do
-        out, err = capture_io { adapter.print_collection(fields, empty_data) }
+        out, _ = capture_io { adapter.print_collection(fields, empty_data) }
         out.must_match(/.*Name.*/)
       end
 
@@ -202,7 +202,7 @@ describe HammerCLI::Output::Adapter::CSValues do
         end
 
         adapter = HammerCLI::Output::Adapter::CSValues.new({}, { :Field => [ DotFormatter.new ]})
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
 
@@ -215,7 +215,7 @@ describe HammerCLI::Output::Adapter::CSValues do
 
         adapter = HammerCLI::Output::Adapter::CSValues.new({}, { :Field => [ NilFormatter.new ]})
         nil_data = HammerCLI::Output::RecordCollection.new [{ :name => nil }]
-        out, err = capture_io { adapter.print_collection([field_name], nil_data) }
+        out, _ = capture_io { adapter.print_collection([field_name], nil_data) }
         out.must_match(/.*NIL.*/)
       end
     end

--- a/test/unit/output/adapter/csv_test.rb
+++ b/test/unit/output/adapter/csv_test.rb
@@ -24,28 +24,28 @@ describe HammerCLI::Output::Adapter::CSValues do
 
     it "should print column name" do
       out, err = capture_io { adapter.print_collection(fields, data) }
-      out.must_match /.*Name,Started At.*/
-      err.must_match //
+      out.must_match(/.*Name,Started At.*/)
+      err.must_match(//)
     end
 
     it "should print field value" do
       out, err = capture_io { adapter.print_collection(fields, data) }
-      out.must_match /.*John Doe.*/
-      err.must_match //
+      out.must_match(/.*John Doe.*/)
+      err.must_match(//)
     end
 
     it "does not print fields which data are missing from api by default" do
       fields << field_login
       out, err = capture_io { adapter.print_collection(fields, data) }
-      out.wont_match /.*Login.*/
-      err.must_match //
+      out.wont_match(/.*Login.*/)
+      err.must_match(//)
     end
 
     it "prints fields which data are missing from api when field has hide_missing flag set to false" do
       fields << field_missing
       out, err = capture_io { adapter.print_collection(fields, data) }
-      out.must_match /.*Missing.*/
-      err.must_match //
+      out.must_match(/.*Missing.*/)
+      err.must_match(//)
     end
 
     context "handle ids" do
@@ -127,14 +127,14 @@ describe HammerCLI::Output::Adapter::CSValues do
 
       it "should print column names" do
         out, err = capture_io { adapter.print_collection(fields, data) }
-        out.must_match /.*Demographics::Age,Demographics::Gender,Biometrics::Weight,Biometrics::Height*/
-        err.must_match //
+        out.must_match(/.*Demographics::Age,Demographics::Gender,Biometrics::Weight,Biometrics::Height*/)
+        err.must_match(//)
       end
 
       it "should print data" do
         out, err = capture_io { adapter.print_collection(fields, data) }
-        out.must_match /.*2000,22,m,123,155*/
-        err.must_match //
+        out.must_match(/.*2000,22,m,123,155*/)
+        err.must_match(//)
       end
     end
 
@@ -169,7 +169,7 @@ describe HammerCLI::Output::Adapter::CSValues do
         lines = out.split("\n")
         lines[0].must_equal 'Name,Started At,Items::Item Name::1,Items::Item Quantity::1,Items::Item Name::2,Items::Item Quantity::2'
 
-        err.must_match //
+        err.must_match(//)
       end
 
       it "should print collection data" do
@@ -179,7 +179,7 @@ describe HammerCLI::Output::Adapter::CSValues do
         lines[1].must_equal 'John Doe,2000,hammer,100,"",""'
         lines[2].must_equal 'Jane Roe,2001,cleaver,1,sledge,50'
 
-        err.must_match //
+        err.must_match(//)
       end
 
       it "should handle empty collection" do
@@ -188,7 +188,7 @@ describe HammerCLI::Output::Adapter::CSValues do
 
         lines[0].must_equal 'Name,Started At,Items'
 
-        err.must_match //
+        err.must_match(//)
       end
 
     end

--- a/test/unit/output/adapter/table_test.rb
+++ b/test/unit/output/adapter/table_test.rb
@@ -94,7 +94,7 @@ describe HammerCLI::Output::Adapter::Table do
       }
 
       it "should ommit column of type Id by default" do
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.wont_match(/.*ID.*/)
       end
 
@@ -110,7 +110,7 @@ describe HammerCLI::Output::Adapter::Table do
 
       it "should print column of type Id when --show-ids is set" do
         adapter = HammerCLI::Output::Adapter::Table.new( { :show_ids => true } )
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*ID.*/)
       end
 
@@ -128,12 +128,12 @@ describe HammerCLI::Output::Adapter::Table do
 
     context "handle headers" do
       it "should print headers by default" do
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*NAME.*/)
       end
 
       it "should print headers by default even if there is no data" do
-        out, err = capture_io { adapter.print_collection(fields, empty_data) }
+        out, _ = capture_io { adapter.print_collection(fields, empty_data) }
         out.must_match(/.*NAME.*/)
       end
 
@@ -353,7 +353,7 @@ describe HammerCLI::Output::Adapter::Table do
         end
 
         adapter = HammerCLI::Output::Adapter::Table.new({}, { :Field => [ DotFormatter.new ]})
-        out, err = capture_io { adapter.print_collection(fields, data) }
+        out, _ = capture_io { adapter.print_collection(fields, data) }
         out.must_match(/.*-DOT-.*/)
       end
 


### PR DESCRIPTION
This PR updates `rake` to any latest available and updates `clamp` to be any version, but `2.0.0` (currently, the latest is 1.3.2).

There is also some refactoring due to `clamp` changes and some refactoring due to `rake` spamming a lot of Ruby warnings. I fixed majority of them (mostly it was `uninitialized variable` warning, although I'm not sure that's a good idea: https://bugs.ruby-lang.org/issues/17055#note-6)

Anyway, there is a new `warning` flag for `rake`'s `TestTask`, which suppresses all Ruby warnings. Without this flag quite a lot of our tests will fail since they depend on strict output. I left `RUBY_WARNINGS` env variable to be set to run the tests with Ruby warnings.