### PR TITLE
Fixes #36258 - Improve regex for KeyValueList normalizer

### DIFF
--- a/lib/hammer_cli/options/normalizers.rb
+++ b/lib/hammer_cli/options/normalizers.rb
@@ -50,9 +50,7 @@ module HammerCLI
       end
 
       class KeyValueList < AbstractNormalizer
-
-        PAIR_RE = '([^,=]+)=([^,\{\[]+|[\{\[][^\{\}\[\]]*[\}\]])'
-        FULL_RE = "^((%s)[,]?)+$" % PAIR_RE
+        FULL_RE = '([^=,]+)=([\{\[][^\{\}\[\]]*[\}\]]|[^\0]+?)(?=,[^,]+=|$)'
 
         class << self
           def completion_type
@@ -68,7 +66,6 @@ module HammerCLI
         def format(val)
           return {} unless val.is_a?(String)
           return {} if val.empty?
-
           if valid_key_value?(val)
             parse_key_value(val)
           else
@@ -89,7 +86,7 @@ module HammerCLI
 
         def parse_key_value(val)
           result = {}
-          val.scan(Regexp.new(PAIR_RE)) do |key, value|
+          val.scan(Regexp.new(FULL_RE)) do |key, value|
             value = value.strip
             if value.start_with?('[')
               value = value.scan(/[^,\[\]]+/)

--- a/test/unit/options/normalizers_test.rb
+++ b/test/unit/options/normalizers_test.rb
@@ -169,6 +169,10 @@ describe HammerCLI::Options::Normalizers do
     end
 
     describe 'key=value format' do
+      it 'should parse values with commas' do
+        _(formatter.format('a=1,2,b=3,4')).must_equal({ 'a' => '1,2', 'b' => '3,4'})
+      end
+
       it "should parse a comma separated string" do
         _(formatter.format("a=1,b=2,c=3")).must_equal({'a' => '1', 'b' => '2', 'c' => '3'})
       end
@@ -236,7 +240,7 @@ describe HammerCLI::Options::Normalizers do
       end
 
       it "should parse a comma separated string 2" do
-        _{ formatter.format("a=1,b,c=3") }.must_raise ArgumentError
+        _(formatter.format("a=1,b,c=3")).must_equal({ 'a' => '1,b', 'c' => '3' })
       end
 
       it 'should parse explicit strings' do


### PR DESCRIPTION
This fixes the issue, but as a downside, we will slightly change the old behavior: previously the normalizer will fail on inputs like `a=1,2,c=3`, which implies that `2` should've had `b` as a key. But we can't really decide for users whether it's a typo or the actual value, thus it will be treated as a value now, which is kinda make sense for quite simple values which don't work now :/

Other approach will be forcing comma escaping if the comma must be a part of the value, but this seems more safer in terms backwards compatibility (previously on wrong input the script will fail, but with that change the stuff that worked might stop working). 