### PR TITLE
Drop unicode gem

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -32,7 +32,6 @@ EOF
   s.add_dependency 'clamp', '>= 1.3.1', '< 2.0.0'
   s.add_dependency 'logging'
   s.add_dependency 'unicode-display_width'
-  s.add_dependency 'unicode'
   s.add_dependency 'amazing_print'
   s.add_dependency 'highline'
   s.add_dependency 'fast_gettext'

--- a/lib/hammer_cli/help/builder.rb
+++ b/lib/hammer_cli/help/builder.rb
@@ -1,4 +1,3 @@
-require 'unicode'
 module HammerCLI
   module Help
     class Builder < Clamp::Help::Builder
@@ -46,7 +45,7 @@ module HammerCLI
                                else
                                  item.help
                                end
-          description.gsub(/^(.)/) { Unicode.capitalize(Regexp.last_match(1)) }.wrap.each_line do |line|
+          description.gsub(/^(.)/) { Regexp.last_match(1).capitalize }.wrap.each_line do |line|
             line " %-#{label_width}s %s" % [label, line]
             label = ''
           end


### PR DESCRIPTION
As of Ruby 2.4 strings can natively handle unicode capitalization and the (very old) unicode gem is no longer required.