### PR TITLE
Log module loading warning to stderr

### DIFF
--- a/lib/hammer_cli/modules.rb
+++ b/lib/hammer_cli/modules.rb
@@ -54,7 +54,7 @@ module HammerCLI
         require_module(name)
       rescue Exception => e
         logger.error "Error while loading module #{name}."
-        puts _("Warning: An error occured while loading module %s.") % name
+        $stderr.puts _("Warning: An error occurred while loading module %s.") % name
         # with ModuleLoadingError we assume the error is already logged by the issuer
         logger.error e unless e.is_a?(HammerCLI::ModuleLoadingError)
         raise e

--- a/test/unit/modules_test.rb
+++ b/test/unit/modules_test.rb
@@ -128,26 +128,25 @@ describe HammerCLI::Modules do
       before :each do
         HammerCLI::Modules.stubs(:require_module).raises(RuntimeError)
         @error_msg = "ERROR  Modules : Error while loading module hammer_cli_tom."
-        @warning_msg = "Warning: An error occured while loading module hammer_cli_tom."
+        @warning_msg = "Warning: An error occurred while loading module hammer_cli_tom."
       end
 
       it "must log an error if the load! fails" do
-        out, _ = capture_io do
+        assert_output("", "#{@warning_msg}\n") do
           assert_raises(RuntimeError) { HammerCLI::Modules.load!('hammer_cli_tom') }
         end
-        _(out).must_equal "#{@warning_msg}\n"
         _(@log_output.readline.strip).must_equal @error_msg
       end
 
       it "must log an error if the load fails" do
-        assert_output("#{@warning_msg}\n", "") do
+        assert_output("", "#{@warning_msg}\n") do
           HammerCLI::Modules.load("hammer_cli_tom")
         end
         _(@log_output.readline.strip).must_equal @error_msg
       end
 
       it "must return false when load fails" do
-        assert_output("#{@warning_msg}\n", "") do
+        assert_output("", "#{@warning_msg}\n") do
           _(HammerCLI::Modules.load("hammer_cli_tom")).must_equal false
         end
       end


### PR DESCRIPTION
When requesting output as JSON the warnings on stdout will prevent loading. It also fixes a typo in occurred.