### PR TITLE
Make clear_cache safe if no completion file is set

### DIFF
--- a/lib/hammer_cli/utils.rb
+++ b/lib/hammer_cli/utils.rb
@@ -55,8 +55,9 @@ module HammerCLI
   end
 
   def self.clear_cache
-    cache_file = File.expand_path(HammerCLI::Settings.get(:completion_cache_file))
-    File.delete(cache_file) if File.exist?(cache_file)
+    if (completion_file = HammerCLI::Settings.get(:completion_cache_file))
+      FileUtils.rm_f(File.expand_path(completion_file))
+    end
   end
 
   def self.interactive?


### PR DESCRIPTION
If it returns `nil`, `expand_path` fails. It also replaces a file deletion race condition with an atomic remove.

Observed a failure in https://github.com/theforeman/hammer-cli/pull/385. I suspect it failed because `HOME` wasn't set, but didn't dig in further.