### PR TITLE
pin FFI to < 1.17 for Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
+# FFI 1.17 needs rubygems 3.3.22+, which is Ruby 3.0+ only
+gem "ffi", "<1.17" if RUBY_VERSION < '3.0'
+
 group :test do
   gem 'rake'
   gem 'thor'


### PR DESCRIPTION
FFI 1.17 needs rubygems 3.3.22+, which is Ruby 3.0+ only
