### PR TITLE
Use non-deprecated GPL-3.0-only license tag

### DIFF
--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors       = ["Martin Bačovský", "Tomáš Strachota"]
   s.email         = "mbacovsk@redhat.com"
   s.homepage      = "https://github.com/theforeman/hammer-cli"
-  s.license       = "GPL-3.0"
+  s.license       = "GPL-3.0-only"
 
   s.summary       = %q{Universal command-line interface}
   s.description   = <<EOF


### PR DESCRIPTION
Just to track some plugins:
 - https://github.com/theforeman/hammer-cli-foreman/pull/632
 - https://github.com/theforeman/hammer_cli_foreman_openscap/pull/51
 - https://github.com/theforeman/hammer-cli-foreman-webhooks/pull/12
 - https://github.com/theforeman/hammer-cli-foreman-ansible/pull/33
 - https://github.com/theforeman/hammer_cli_foreman_bootdisk/pull/20
 - https://github.com/theforeman/hammer-cli-foreman-google/pull/12
 - https://github.com/theforeman/hammer-cli-foreman-puppet/pull/55
 - https://github.com/theforeman/hammer-cli-foreman-tasks/pull/59