### PR TITLE
Fixes #38077 - Don't build hidden params as options

### DIFF
--- a/lib/hammer_cli/apipie/option_builder.rb
+++ b/lib/hammer_cli/apipie/option_builder.rb
@@ -30,6 +30,7 @@ module HammerCLI::Apipie
     def options_for_params(params, filter, resource_name_map, opts = {})
       options = []
       params.each do |p|
+        next unless p.show?
         exists = opts[:command].find_option(option_switch(p, resource_name_map))
         next if filter.include?(p.name) || filter.include?(p.name.to_sym) || exists
 
@@ -85,6 +86,7 @@ module HammerCLI::Apipie
       opts[:attribute_name] = HammerCLI.option_accessor_name(param.name)
       opts[:referenced_resource] = resource_name(param)
       opts[:aliased_resource] = aliased_name(resource_name(param), resource_name_map)
+      opts[:show] = param.show?
 
       return opts
     end

--- a/lib/hammer_cli/options/option_definition.rb
+++ b/lib/hammer_cli/options/option_definition.rb
@@ -30,6 +30,8 @@ module HammerCLI
         @context_target = options[:context_target]
         @deprecated_switches = options[:deprecated]
         @family = options[:family]
+        # We expect a value from API param docs, but in case it's not there, we want to show it in help by default
+        @show = options.fetch(:show, true)
         super
       end
 
@@ -151,6 +153,10 @@ module HammerCLI
         return unless @family
 
         @family.children.include?(self)
+      end
+
+      def show?
+        @show
       end
 
       private

--- a/test/unit/apipie/option_builder_test.rb
+++ b/test/unit/apipie/option_builder_test.rb
@@ -178,4 +178,14 @@ describe HammerCLI::Apipie::OptionBuilder do
     end
   end
 
+  context "hidden parameters" do
+    let(:action) { resource.action(:create) }
+
+    it "should skip options for params with show? false" do
+      option_switches = options.map(&:long_switch)
+      refute_includes(option_switches, "--hidden")
+      refute_includes(option_switches, "--documented-scope")
+    end
+  end
+
 end

--- a/test/unit/fixtures/apipie/documented.json
+++ b/test/unit/fixtures/apipie/documented.json
@@ -77,6 +77,16 @@
                         "params": [
                             {
                                 "allow_null": false,
+                                "name": "documented_scope",
+                                "full_name": "documented_scope",
+                                "validator": "Must be String",
+                                "description": "",
+                                "expected_type": "string",
+                                "required": false,
+                                "show": false
+                            },
+                            {
+                                "allow_null": false,
                                 "name": "documented",
                                 "full_name": "documented",
                                 "validator": "Must be a Hash",
@@ -110,6 +120,16 @@
                                         "expected_type": "array",
                                         "description": "",
                                         "required": true
+                                    },
+                                    {
+                                        "name": "hidden",
+                                        "allow_null": false,
+                                        "full_name": "documented[hidden]",
+                                        "validator": "Must be number",
+                                        "expected_type": "number",
+                                        "description": "",
+                                        "required": false,
+                                        "show": false
                                     }
                                 ]
                             }


### PR DESCRIPTION
Requires:
 - https://github.com/Apipie/apipie-bindings/pull/84

Used in:
 - https://github.com/theforeman/hammer-cli-foreman/pull/634

@adamlazik1, you might be interested in this, since it tries to use your changes in https://github.com/theforeman/foreman/pull/10322.