### PR TITLE
Use master branch of apipie-bindings in CI

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -19,10 +19,19 @@ jobs:
           - '3.1'
 
     steps:
+      - name: Get apipie-bindings
+        uses: actions/checkout@v2
+        with:
+          repository: Apipie/apipie-bindings
+          ref: master
+          path: apipie-bindings
       - name: Get hammer-cli
         uses: actions/checkout@v2
         with:
           path: hammer-cli
+      - name: Configure local gem dependencies
+        run: |
+          echo "gemspec path: '../apipie-bindings', name: 'apipie-bindings'" > Gemfile.local.rb
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
It should make easier to test open PRs for apipie-bindings by changing `repository` and `ref` in an open PR for this repo.