### PR TITLE
Ruby 3.4 compatibility

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Get apipie-bindings
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: Apipie/apipie-bindings
           ref: master
           path: apipie-bindings
       - name: Get hammer-cli
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: hammer-cli
       - name: Configure local gem dependencies

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -17,6 +17,9 @@ jobs:
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4'
 
     steps:
       - name: Get apipie-bindings

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -31,7 +31,9 @@ EOF
 
   s.add_dependency 'amazing_print'
   s.add_dependency 'apipie-bindings', '>= 0.7.0'
+  s.add_dependency 'base64' # oauth requires this but doesn't depend on it
   s.add_dependency 'clamp', '>= 1.3.1', '< 2.0.0'
+  s.add_dependency 'csv'
   s.add_dependency 'fast_gettext'
   s.add_dependency 'highline'
   s.add_dependency 'locale', '>= 2.0.6'

--- a/hammer_cli.gemspec
+++ b/hammer_cli.gemspec
@@ -29,13 +29,12 @@ EOF
 
   s.required_ruby_version = '>= 2.7'
 
+  s.add_dependency 'amazing_print'
+  s.add_dependency 'apipie-bindings', '>= 0.7.0'
   s.add_dependency 'clamp', '>= 1.3.1', '< 2.0.0'
+  s.add_dependency 'fast_gettext'
+  s.add_dependency 'highline'
+  s.add_dependency 'locale', '>= 2.0.6'
   s.add_dependency 'logging'
   s.add_dependency 'unicode-display_width'
-  s.add_dependency 'amazing_print'
-  s.add_dependency 'highline'
-  s.add_dependency 'fast_gettext'
-  s.add_dependency 'locale', '>= 2.0.6'
-  s.add_dependency 'apipie-bindings', '>= 0.7.0'
-
 end

--- a/test/unit/abstract_test.rb
+++ b/test/unit/abstract_test.rb
@@ -185,7 +185,7 @@ describe HammerCLI::AbstractCommand do
       test_command_class.option(['--password'], 'PASSWORD', 'Password')
       test_command = test_command_class.new("")
       test_command.run ['--password=pass']
-      _(@log_output.readline.strip).must_equal "INFO  HammerCLI::AbstractCommand : Called with options: {\"option_password\"=>\"***\"}"
+      _(@log_output.readline.strip).must_match(%r{INFO  HammerCLI::AbstractCommand : Called with options: {\"option_password\"\s*=>\s*\"\*\*\*\"}})
     end
   end
 


### PR DESCRIPTION
This is a warning raised on Ruby 3.3:

    lib/hammer_cli/output/adapter.rb:5: warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.

It also raises one about syslog:

    lib/hammer_cli/settings.rb:2: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.

However, this one is pulled in via logging and we don't care about syslog. https://github.com/TwP/logging/issues/247 says this is a Ruby bug so we may need to accept it.