### PR TITLE
Fixes #38410 - Add mechanism for deprecating displayed fields

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -755,6 +755,35 @@ def adapter
 end
 ```
 
+#### Deprecating fields
+To deprecate a field, add `:deprecated => true` as an option for the field. This will print a warning message to stderr whenever the field is displayed. Consider removing this field from the default set so it is not displayed without a `--fields` param:
+
+```
+field :dep_fld, _("Deprecated field"), Fields::Field, :sets => ['ALL'], :deprecated => true
+```
+
+Example output:
+
+```
+$ hammer foo info --fields "Deprecated field"
+Warning: Field 'Deprecated field' is deprecated and may be removed in future versions.
+Deprecated field: bar
+```
+
+Additionally, a field may be 'replaced by' another field using `:replaced_by => "Path/To/New/Field"`. This will mark the field as deprecated and print a similar warning message to stderr whenever the field is displayed:
+
+```
+field :rep_fld, _("Replaced field"), Fields::Field, :sets => ['ALL'], :replaced_by => "Path/New field"
+```
+
+Example output:
+
+```
+$ hammer foo info --fields "Replaced field"
+Warning: Field 'Replaced field' is deprecated. Consider using 'Path/New field' instead.
+Replaced field: bar
+```
+
 #### Verbosity
 Currently Hammer [defines](https://github.com/theforeman/hammer-cli/blob/master/lib/hammer_cli/verbosity.rb) three basic verbose modes:
   * __QUIET__ - Prints nothing

--- a/lib/hammer_cli/output/adapter/base.rb
+++ b/lib/hammer_cli/output/adapter/base.rb
@@ -42,6 +42,12 @@ module HammerCLI::Output::Adapter
     end
 
     def render_field(field, data, label_width)
+      if field.replaced_by
+        warn "WARNING: Field '#{field.full_label}' is deprecated. Consider using '#{field.replaced_by}' instead."
+      elsif field.deprecated
+        warn "WARNING: Field '#{field.full_label}' is deprecated and may be removed in future versions."
+      end
+
       if field.is_a? Fields::ContainerField
         output = ""
 

--- a/lib/hammer_cli/output/fields.rb
+++ b/lib/hammer_cli/output/fields.rb
@@ -4,7 +4,7 @@ module Fields
   class Field
     attr_reader :path
     attr_writer :sets
-    attr_accessor :label, :parent
+    attr_accessor :label, :parent, :replaced_by, :deprecated
 
     def initialize(options={})
       @hide_blank = options[:hide_blank].nil? ? false : options[:hide_blank]
@@ -12,6 +12,8 @@ module Fields
       @path = options[:path] || []
       @label = options[:label]
       @sets = options[:sets]
+      @replaced_by = options[:replaced_by]
+      @deprecated = (options[:deprecated].nil?) ? !@replaced_by.nil? : options[:deprecated]
       @options = options
     end
 


### PR DESCRIPTION
Currently, hammer has no way to deprecate old fields our developers wish to remove. This PR adds an option for deprecating a field with `:deprecated => true`. When a deprecated field is displayed, a stderr warning message is shown indicating it will be removed in the future. Updated `doc/creating_commands.md` to show how to deprecate a field.

**How to test**:

1. Find a field in hammer-cli-foreman or hammer-cli-katello and modify it to have the deprecated flag:
```
field :example, _("Example field"), Fields::Field, :deprecated => true
```
2. When displaying this field, verify that a warning is printed to stderr:
```
WARNING: Field 'Example field' is deprecated and may be removed in future versions.
```
3. Remove this field from the default set and confirm that the error message does not display when the field is not rendered:
```
field :example, _("Example field"), Fields::Field, :sets => ['ALL'], :deprecated => true
```
4. Confirm that the error message does display for a variety of field output edge cases (`--fields`, etc). Ensure output is always sent to stderr.
5. Add the :replaced_by flag and repeat the previous testing steps:
```
field :example, _("Example field"), Fields::Field, :replaced_by => "Example/Path"
```