### PR TITLE
Fixes #38427 - Modify replaced_by to allow for selection of new field by object.

### DIFF
--- a/doc/creating_commands.md
+++ b/doc/creating_commands.md
@@ -755,7 +755,7 @@ def adapter
 end
 ```
 
-#### Deprecating fields
+#### Deprecating and replacing fields
 To deprecate a field, add `:deprecated => true` as an option for the field. This will print a warning message to stderr whenever the field is displayed. Consider removing this field from the default set so it is not displayed without a `--fields` param:
 
 ```
@@ -770,18 +770,22 @@ Warning: Field 'Deprecated field' is deprecated and may be removed in future ver
 Deprecated field: bar
 ```
 
-Additionally, a field may be 'replaced by' another field using `:replaced_by => "Path/To/New/Field"`. This will mark the field as deprecated and print a similar warning message to stderr whenever the field is displayed:
+Additionally, a field may be 'replaced by' another field using `:replaced_by_path => ["relative","path","to","new","field"]`. Use "!p" to indicate the parent field/list/collection and other strings to indicate the id of child field/list/collections. This will mark the field as deprecated and print a similar warning message to stderr whenever the field is displayed.
+
+For example, to replace 'Foo/Bar/Old field' with 'Foo/Baz/New field', do the following:
 
 ```
-field :rep_fld, _("Replaced field"), Fields::Field, :sets => ['ALL'], :replaced_by => "Path/New field"
+field :old_fld, _("Old Field"), Fields::Field, :sets => ['ALL'], :replaced_by => ["!p","!p","baz","new_fld"]
 ```
 
 Example output:
 
 ```
-$ hammer foo info --fields "Replaced field"
-Warning: Field 'Replaced field' is deprecated. Consider using 'Path/New field' instead.
-Replaced field: bar
+$ hammer foo info --fields "Foo/Bar/Old field"
+Warning: Field 'Foo/Bar/Old field' is deprecated. Consider using 'Foo/Baz/New field' instead.
+Foo:
+  Bar:
+    Old field: data
 ```
 
 #### Verbosity

--- a/lib/hammer_cli/output/fields.rb
+++ b/lib/hammer_cli/output/fields.rb
@@ -4,7 +4,7 @@ module Fields
   class Field
     attr_reader :path
     attr_writer :sets
-    attr_accessor :label, :parent, :replaced_by, :deprecated
+    attr_accessor :label, :parent, :replaced_by_path, :deprecated
 
     def initialize(options={})
       @hide_blank = options[:hide_blank].nil? ? false : options[:hide_blank]
@@ -12,8 +12,8 @@ module Fields
       @path = options[:path] || []
       @label = options[:label]
       @sets = options[:sets]
-      @replaced_by = options[:replaced_by]
-      @deprecated = (options[:deprecated].nil?) ? !@replaced_by.nil? : options[:deprecated]
+      @replaced_by_path = options[:replaced_by_path]
+      @deprecated = (options[:deprecated].nil?) ? !@replaced_by_path.nil? : options[:deprecated]
       @options = options
     end
 


### PR DESCRIPTION
Modified the `replaced_by` string on fields to a `replaced_by_path` relative path to another field. This allows for displaying the exact translation of the new path to stderr and can better handle label name changes in the future.

_From the docs:_
A field may be 'replaced by' another field using `:replaced_by_path => ["relative","path","to","new","field"]`. Use "!p" to indicate the parent field/list/collection and other strings to indicate the id of child field/list/collections. This will mark the field as deprecated and print a similar warning message to stderr whenever the field is displayed.

For example, to replace 'Foo/Bar/Old field' with 'Foo/Baz/New field', do the following:

```
field :old_fld, _("Old Field"), Fields::Field, :sets => ['ALL'], :replaced_by => ["!p","!p","baz","new_fld"]
```

Example output:

```
$ hammer foo info --fields "Foo/Bar/Old field"
Warning: Field 'Foo/Bar/Old field' is deprecated. Consider using 'Foo/Baz/New field' instead.
Foo:
  Bar:
    Old field: data
```